### PR TITLE
feat: add TypeORM configuration and customer persistence

### DIFF
--- a/ai/agentic-pipeline/turns/3/adr.md
+++ b/ai/agentic-pipeline/turns/3/adr.md
@@ -1,0 +1,16 @@
+# ADR 3: TypeORM Data Source and Customer Persistence Layer
+
+**Status**: Accepted
+
+**Date**: 2025-09-25
+
+**Context**
+The API required a single source of truth for TypeORM configuration that could be reused by NestJS, the CLI, and migrations while honoring the project-provided environment variables. The customer domain schema from prior turns also needed concrete TypeORM entities, migrations, and NestJS services to persist and query real customer data instead of stubs.
+
+**Decision**
+Use a dedicated `AppDataSource` that loads credentials from `ai/context/.env`, applies the snake-case naming strategy, and exposes build-aware migration globs. Register the same options with `TypeOrmModule.forRoot` so the NestJS runtime and CLI use identical settings. Model the customer, address, email, phone, privacy, and profile view structures as TypeORM entities with a transactional `CustomerService`, wrap them in a `CustomerModule`, and generate an initial migration that creates the schema, tables, indexes, foreign keys, and reporting view.
+
+**Consequences**
+- Positive: Configuration drift between the CLI and NestJS runtime is eliminated, and repository-backed CRUD is available immediately for downstream API work.
+- Positive: The migration establishes database objects aligned with the domain schema, enabling deterministic builds and CI flows.
+- Negative: Additional metadata headers and manual migration maintenance are required as the domain evolves, increasing review overhead.

--- a/ai/agentic-pipeline/turns/3/changelog.md
+++ b/ai/agentic-pipeline/turns/3/changelog.md
@@ -1,0 +1,22 @@
+# Turn: 3 – 2025-09-25T19:49:54Z
+
+## prompt
+execute turn 3
+
+#### Task
+TASK 06 - Create TypeORM Configuration
+#### Changes
+- Implemented a shared `AppDataSource` that reads from `ai/context/.env`, applies the snake-case naming strategy, and registers all customer entities alongside compiled migration globs.
+- Added TypeORM CLI scripts, a connection validation helper, and documented the migration workflow in `api/README.md`.
+- Wired `AppModule` to reuse the centralized TypeORM options and expanded `.gitignore` to exclude build metadata.
+
+#### Task
+TASK 07 — Create Domain Entities
+#### Changes
+- Created TypeORM entities, view, and repositories for customers, emails, phone numbers, postal addresses, and privacy settings with metadata headers.
+- Added a customer domain module plus a repository-backed service that performs transactional create, read, update, and delete operations.
+- Authored the initial migration to create the customer schema, tables, constraints, and reporting view.
+
+#### Tooling & Operations
+- npm run build
+- npm run lint

--- a/ai/agentic-pipeline/turns/3/manifest.json
+++ b/ai/agentic-pipeline/turns/3/manifest.json
@@ -1,0 +1,49 @@
+{
+  "turnId": 3,
+  "timestampUtc": "2025-09-25T19:49:54Z",
+  "task": {
+    "name": "execute turn 3",
+    "tasks": [
+      "TASK 06 - Create TypeORM Configuration",
+      "TASK 07 — Create Domain Entities"
+    ]
+  },
+  "changes": {
+    "added": [
+      "ai/agentic-pipeline/turns/3/adr.md",
+      "ai/agentic-pipeline/turns/3/changelog.md",
+      "ai/agentic-pipeline/turns/3/manifest.json",
+      "ai/agentic-pipeline/turns/3/session_context_values.md",
+      "api/README.md",
+      "api/src/customer/customer.module.ts",
+      "api/src/customer/entities/customer.entity.ts",
+      "api/src/customer/entities/customer_email.entity.ts",
+      "api/src/customer/entities/customer_phone_number.entity.ts",
+      "api/src/customer/entities/customer_profile_view.entity.ts",
+      "api/src/customer/entities/postal_address.entity.ts",
+      "api/src/customer/entities/privacy_settings.entity.ts",
+      "api/src/customer/services/customer.service.ts",
+      "api/src/database/data-source.ts",
+      "api/src/database/validate-connection.ts",
+      "api/src/migrations/20250925193600-CreateCustomerDomainSchema.ts"
+    ],
+    "modified": [
+      "ai/agentic-pipeline/turns/index.csv",
+      "api/.gitignore",
+      "api/package-lock.json",
+      "api/package.json",
+      "api/src/app.module.ts",
+      "changelog.md"
+    ]
+  },
+  "tests": [
+    {
+      "command": "npm run build",
+      "path": "api"
+    },
+    {
+      "command": "npm run lint",
+      "path": "api"
+    }
+  ]
+}

--- a/ai/agentic-pipeline/turns/3/session_context_values.md
+++ b/ai/agentic-pipeline/turns/3/session_context_values.md
@@ -1,0 +1,18 @@
+# Session Context Values
+
+## Globals
+- sandbox_base_directory: workspace
+- agentic-pipeline: codex-agentic-ai-pipeline
+- target_project: codex-customer-registration-nextjs-nestjs
+- project_context: codex-customer-registration-nextjs-nestjs/ai/context
+- turn_task: execute turn 3
+- turn_id: 3
+- application_implementation_pattern: full-stack-app-nextjs-nestjs
+- patterns: ["full-stack-app-nextjs-nestjs", "spring-boot-mvc-jpa-postgresql"]
+
+## Project Context
+- Application Name: Customer Registration
+- Domain Object: Customer
+- REST API Request Schema: ai/context/schemas/customer.schema.json
+- REST API Response Schema: schemas/customer.schema.json
+- Persisted Data Schema: ai/context/schemas/customer_domain-entities.json

--- a/ai/agentic-pipeline/turns/index.csv
+++ b/ai/agentic-pipeline/turns/index.csv
@@ -1,3 +1,4 @@
 turnId,timestampUtc,task,branch,tag,headAfter,testsPassed,testsFailed,coverageDeltaPct
 1,2025-09-25T19:10:45Z,execute turn 1,,,,6,0,
 2,2025-09-25T19:45:00Z,execute turn 2,,,,0,0,
+3,2025-09-25T19:49:54Z,execute turn 3,,,,0,0,

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,13 +1,14 @@
 # App: {{project.name}}
 # Package: api
 # File: .gitignore
-# Version: 0.1.0
-# Turns: 2
+# Version: 0.2.0
+# Turns: 2, 3
 # Author: Codex Agent
-# Date: 2025-09-20T04:22:15Z
+# Date: 2025-09-25T19:36:06Z
 # Exports: (ignore rules)
 # Description: Ignore build artifacts, dependencies, and environment files for the API project.
 /node_modules
 /dist
 /.env
+/.tsbuildinfo
 /coverage

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,25 @@
+# Customer Registration API
+
+## Database and Migrations
+
+1. Start the PostgreSQL instance:
+   ```bash
+   docker compose -f ../db/docker-compose.yml up -d
+   ```
+2. Validate connectivity and credentials:
+   ```bash
+   npm run db:validate
+   ```
+3. Generate a new migration from entity changes:
+   ```bash
+   npm run typeorm:migration:generate -- src/migrations/<Name>
+   ```
+4. Build the project and apply compiled migrations (CI / production):
+   ```bash
+   npm run build
+   npm run typeorm:migration:run:js
+   ```
+5. Revert the latest compiled migration if required:
+   ```bash
+   npm run typeorm:migration:revert:js
+   ```

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -23,7 +23,8 @@
         "pg": "^8.16.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.2",
-        "typeorm": "^0.3.24"
+        "typeorm": "^0.3.24",
+        "typeorm-naming-strategies": "^4.1.0"
       },
       "devDependencies": {
         "@nestjs/cli": "^11.0.7",
@@ -13117,6 +13118,15 @@
         "typeorm-aurora-data-api-driver": {
           "optional": true
         }
+      }
+    },
+    "node_modules/typeorm-naming-strategies": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/typeorm-naming-strategies/-/typeorm-naming-strategies-4.1.0.tgz",
+      "integrity": "sha512-vPekJXzZOTZrdDvTl1YoM+w+sUIfQHG4kZTpbFYoTsufyv9NIBRe4Q+PdzhEAFA2std3D9LZHEb1EjE9zhRpiQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typeorm": "^0.2.0 || ^0.3.0"
       }
     },
     "node_modules/typeorm/node_modules/ansis": {

--- a/api/package.json
+++ b/api/package.json
@@ -17,7 +17,14 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "typeorm:migration:generate": "typeorm migration:generate src/migrations/Auto -d src/database/data-source.ts",
+    "typeorm:migration:create": "typeorm migration:create src/migrations/Manual",
+    "typeorm:migration:run": "node --require ts-node/register ./node_modules/typeorm/cli.js migration:run -d src/database/data-source.ts",
+    "typeorm:migration:revert": "node --require ts-node/register ./node_modules/typeorm/cli.js migration:revert -d src/database/data-source.ts",
+    "typeorm:migration:run:js": "node ./node_modules/typeorm/cli.js migration:run -d dist/database/data-source.js",
+    "typeorm:migration:revert:js": "node ./node_modules/typeorm/cli.js migration:revert -d dist/database/data-source.js",
+    "db:validate": "ts-node src/database/validate-connection.ts"
   },
   "dependencies": {
     "@nestjs/axios": "^4.0.0",
@@ -34,7 +41,8 @@
     "pg": "^8.16.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
-    "typeorm": "^0.3.24"
+    "typeorm": "^0.3.24",
+    "typeorm-naming-strategies": "^4.1.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.7",

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -2,17 +2,24 @@
  * App: Customer Registration
  * Package: api/src
  * File: app.module.ts
- * Version: 0.1.0
- * Turns: 1
+ * Version: 0.2.0
+ * Turns: 1, 3
  * Author: Codex Agent
- * Date: 2025-09-25T19:06:09Z
+ * Date: 2025-09-25T19:36:06Z
  * Exports: AppModule
  * Description: Defines the root NestJS application module that composes feature modules.
  */
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AppDataSource } from './database/data-source';
+import { CustomerModule } from './customer/customer.module';
 import { HealthModule } from './health/health.module';
 
 @Module({
-  imports: [HealthModule],
+  imports: [
+    TypeOrmModule.forRoot(AppDataSource.options),
+    HealthModule,
+    CustomerModule,
+  ],
 })
 export class AppModule {}

--- a/api/src/customer/customer.module.ts
+++ b/api/src/customer/customer.module.ts
@@ -1,0 +1,36 @@
+/**
+ * App: Customer Registration
+ * Package: api/src/customer
+ * File: customer.module.ts
+ * Version: 0.1.0
+ * Turns: 3
+ * Author: Codex Agent
+ * Date: 2025-09-25T19:36:06Z
+ * Exports: CustomerModule
+ * Description: Registers customer domain repositories and services for dependency injection.
+ */
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CustomerEntity } from './entities/customer.entity';
+import { CustomerEmailEntity } from './entities/customer_email.entity';
+import { CustomerPhoneNumberEntity } from './entities/customer_phone_number.entity';
+import { CustomerProfileView } from './entities/customer_profile_view.entity';
+import { PostalAddressEntity } from './entities/postal_address.entity';
+import { PrivacySettingsEntity } from './entities/privacy_settings.entity';
+import { CustomerService } from './services/customer.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      PostalAddressEntity,
+      PrivacySettingsEntity,
+      CustomerEntity,
+      CustomerEmailEntity,
+      CustomerPhoneNumberEntity,
+      CustomerProfileView,
+    ]),
+  ],
+  providers: [CustomerService],
+  exports: [CustomerService],
+})
+export class CustomerModule {}

--- a/api/src/customer/entities/customer.entity.ts
+++ b/api/src/customer/entities/customer.entity.ts
@@ -1,0 +1,90 @@
+/**
+ * App: Customer Registration
+ * Package: api/src/customer/entities
+ * File: customer.entity.ts
+ * Version: 0.1.1
+ * Turns: 3
+ * Author: Codex Agent
+ * Date: 2025-09-25T19:36:06Z
+ * Exports: CustomerEntity
+ * Description: Represents customer records and relations to addresses, privacy settings, emails, and phone numbers.
+ */
+import type { EntityOptions } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  Unique,
+  UpdateDateColumn,
+} from 'typeorm';
+import { CustomerEmailEntity } from './customer_email.entity';
+import { CustomerPhoneNumberEntity } from './customer_phone_number.entity';
+import { PostalAddressEntity } from './postal_address.entity';
+import { PrivacySettingsEntity } from './privacy_settings.entity';
+
+const schemaName = process.env.DATABASE_SCHEMA;
+const entityOptions: EntityOptions = {
+  name: 'customers',
+  ...(schemaName ? { schema: schemaName } : {}),
+};
+
+@Entity(entityOptions)
+@Unique('ux_customers_email', ['email'])
+@Index('ix_customers_address_id', ['addressId'])
+@Index('ix_customers_privacy_settings_id', ['privacySettingsId'])
+export class CustomerEntity {
+  @PrimaryGeneratedColumn('uuid', { name: 'customer_id' })
+  public customerId!: string;
+
+  @Column({ name: 'name', type: 'varchar', length: 255 })
+  public name!: string;
+
+  @Column({ name: 'first_name', type: 'varchar', length: 120 })
+  public firstName!: string;
+
+  @Column({ name: 'middle_name', type: 'varchar', length: 120, nullable: true })
+  public middleName?: string | null;
+
+  @Column({ name: 'last_name', type: 'varchar', length: 120 })
+  public lastName!: string;
+
+  @Column({ name: 'email', type: 'varchar', length: 255 })
+  public email!: string;
+
+  @Column({ name: 'address_id', type: 'integer', nullable: true })
+  public addressId?: number | null;
+
+  @Column({ name: 'privacy_settings_id', type: 'integer', nullable: true })
+  public privacySettingsId?: number | null;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  public createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamptz' })
+  public updatedAt!: Date;
+
+  @ManyToOne(() => PostalAddressEntity, (address) => address.customers, {
+    nullable: true,
+    onDelete: 'SET NULL',
+  })
+  @JoinColumn({ name: 'address_id', referencedColumnName: 'addressId' })
+  public address?: PostalAddressEntity | null;
+
+  @ManyToOne(() => PrivacySettingsEntity, (privacy) => privacy.customers, {
+    nullable: true,
+    onDelete: 'SET NULL',
+  })
+  @JoinColumn({ name: 'privacy_settings_id', referencedColumnName: 'privacySettingsId' })
+  public privacySettings?: PrivacySettingsEntity | null;
+
+  @OneToMany(() => CustomerEmailEntity, (email) => email.customer)
+  public emails?: CustomerEmailEntity[];
+
+  @OneToMany(() => CustomerPhoneNumberEntity, (phoneNumber) => phoneNumber.customer)
+  public phoneNumbers?: CustomerPhoneNumberEntity[];
+}

--- a/api/src/customer/entities/customer_email.entity.ts
+++ b/api/src/customer/entities/customer_email.entity.ts
@@ -1,0 +1,55 @@
+/**
+ * App: Customer Registration
+ * Package: api/src/customer/entities
+ * File: customer_email.entity.ts
+ * Version: 0.1.1
+ * Turns: 3
+ * Author: Codex Agent
+ * Date: 2025-09-25T19:36:06Z
+ * Exports: CustomerEmailEntity
+ * Description: Maps customer email addresses with uniqueness per customer and optional primary flag.
+ */
+import type { EntityOptions } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { CustomerEntity } from './customer.entity';
+
+const schemaName = process.env.DATABASE_SCHEMA;
+const entityOptions: EntityOptions = {
+  name: 'customer_emails',
+  ...(schemaName ? { schema: schemaName } : {}),
+};
+
+@Entity(entityOptions)
+@Index('ix_customer_emails_customer_id', ['customerId'])
+@Index('ux_customer_emails_customer_id_email', ['customerId', 'email'], { unique: true })
+export class CustomerEmailEntity {
+  @PrimaryGeneratedColumn({ name: 'email_id', type: 'integer' })
+  public emailId!: number;
+
+  @Column({ name: 'customer_id', type: 'uuid' })
+  public customerId!: string;
+
+  @Column({ name: 'email', type: 'varchar', length: 255 })
+  public email!: string;
+
+  @Column({ name: 'is_primary', type: 'boolean' })
+  public isPrimary!: boolean;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  public createdAt!: Date;
+
+  @ManyToOne(() => CustomerEntity, (customer) => customer.emails, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'customer_id', referencedColumnName: 'customerId' })
+  public customer!: CustomerEntity;
+}

--- a/api/src/customer/entities/customer_phone_number.entity.ts
+++ b/api/src/customer/entities/customer_phone_number.entity.ts
@@ -1,0 +1,60 @@
+/**
+ * App: Customer Registration
+ * Package: api/src/customer/entities
+ * File: customer_phone_number.entity.ts
+ * Version: 0.1.1
+ * Turns: 3
+ * Author: Codex Agent
+ * Date: 2025-09-25T19:36:06Z
+ * Exports: CustomerPhoneNumberEntity
+ * Description: Maps customer phone numbers with uniqueness per customer/type combination.
+ */
+import type { EntityOptions } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { CustomerEntity } from './customer.entity';
+
+const schemaName = process.env.DATABASE_SCHEMA;
+const entityOptions: EntityOptions = {
+  name: 'customer_phone_numbers',
+  ...(schemaName ? { schema: schemaName } : {}),
+};
+
+@Entity(entityOptions)
+@Index('ix_customer_phone_numbers_customer_id', ['customerId'])
+@Index('ux_customer_phone_numbers_customer_id_type_number', ['customerId', 'type', 'number'], {
+  unique: true,
+})
+export class CustomerPhoneNumberEntity {
+  @PrimaryGeneratedColumn({ name: 'phone_id', type: 'integer' })
+  public phoneId!: number;
+
+  @Column({ name: 'customer_id', type: 'uuid' })
+  public customerId!: string;
+
+  @Column({ name: 'type', type: 'varchar', length: 20 })
+  public type!: string;
+
+  @Column({ name: 'number', type: 'varchar', length: 20 })
+  public number!: string;
+
+  @Column({ name: 'extension', type: 'varchar', length: 10, nullable: true })
+  public extension?: string | null;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  public createdAt!: Date;
+
+  @ManyToOne(() => CustomerEntity, (customer) => customer.phoneNumbers, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'customer_id', referencedColumnName: 'customerId' })
+  public customer!: CustomerEntity;
+}

--- a/api/src/customer/entities/customer_profile_view.entity.ts
+++ b/api/src/customer/entities/customer_profile_view.entity.ts
@@ -1,0 +1,90 @@
+/**
+ * App: Customer Registration
+ * Package: api/src/customer/entities
+ * File: customer_profile_view.entity.ts
+ * Version: 0.1.2
+ * Turns: 3
+ * Author: Codex Agent
+ * Date: 2025-09-25T19:36:06Z
+ * Exports: CustomerProfileView
+ * Description: Projects read-optimized customer profile data from customers, addresses, and privacy settings.
+ */
+import { DataSource, ViewColumn, ViewEntity } from 'typeorm';
+import { CustomerEntity } from './customer.entity';
+import { PostalAddressEntity } from './postal_address.entity';
+import { PrivacySettingsEntity } from './privacy_settings.entity';
+
+const schemaName = process.env.DATABASE_SCHEMA;
+
+const viewOptions = {
+  name: 'customer_profile_view',
+  expression: (dataSource: DataSource) =>
+    dataSource
+      .createQueryBuilder(CustomerEntity, 'customer')
+      .leftJoin(PostalAddressEntity, 'address', 'address.address_id = customer.address_id')
+      .leftJoin(
+        PrivacySettingsEntity,
+        'privacy',
+        'privacy.privacy_settings_id = customer.privacy_settings_id',
+      )
+      .select('customer.customer_id', 'customer_id')
+      .addSelect('customer.name', 'name')
+      .addSelect('customer.first_name', 'first_name')
+      .addSelect('customer.middle_name', 'middle_name')
+      .addSelect('customer.last_name', 'last_name')
+      .addSelect('customer.email', 'email')
+      .addSelect('address.line1', 'line1')
+      .addSelect('address.line2', 'line2')
+      .addSelect('address.city', 'city')
+      .addSelect('address.state', 'state')
+      .addSelect('address.postal_code', 'postal_code')
+      .addSelect('address.country', 'country')
+      .addSelect('privacy.marketing_emails_enabled', 'marketing_emails_enabled')
+      .addSelect('privacy.two_factor_enabled', 'two_factor_enabled'),
+  ...(schemaName ? { schema: schemaName } : {}),
+} as const;
+
+@ViewEntity(viewOptions)
+export class CustomerProfileView {
+  @ViewColumn({ name: 'customer_id' })
+  public customerId!: string;
+
+  @ViewColumn({ name: 'name' })
+  public name!: string;
+
+  @ViewColumn({ name: 'first_name' })
+  public firstName!: string;
+
+  @ViewColumn({ name: 'middle_name' })
+  public middleName?: string | null;
+
+  @ViewColumn({ name: 'last_name' })
+  public lastName!: string;
+
+  @ViewColumn({ name: 'email' })
+  public email!: string;
+
+  @ViewColumn({ name: 'line1' })
+  public line1?: string | null;
+
+  @ViewColumn({ name: 'line2' })
+  public line2?: string | null;
+
+  @ViewColumn({ name: 'city' })
+  public city?: string | null;
+
+  @ViewColumn({ name: 'state' })
+  public state?: string | null;
+
+  @ViewColumn({ name: 'postal_code' })
+  public postalCode?: string | null;
+
+  @ViewColumn({ name: 'country' })
+  public country?: string | null;
+
+  @ViewColumn({ name: 'marketing_emails_enabled' })
+  public marketingEmailsEnabled?: boolean | null;
+
+  @ViewColumn({ name: 'two_factor_enabled' })
+  public twoFactorEnabled?: boolean | null;
+}

--- a/api/src/customer/entities/postal_address.entity.ts
+++ b/api/src/customer/entities/postal_address.entity.ts
@@ -1,0 +1,60 @@
+/**
+ * App: Customer Registration
+ * Package: api/src/customer/entities
+ * File: postal_address.entity.ts
+ * Version: 0.1.1
+ * Turns: 3
+ * Author: Codex Agent
+ * Date: 2025-09-25T19:36:06Z
+ * Exports: PostalAddressEntity
+ * Description: Defines the postal_addresses table mapping for storing structured mailing addresses.
+ */
+import type { EntityOptions } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { CustomerEntity } from './customer.entity';
+
+const schemaName = process.env.DATABASE_SCHEMA;
+const entityOptions: EntityOptions = {
+  name: 'postal_addresses',
+  ...(schemaName ? { schema: schemaName } : {}),
+};
+
+@Entity(entityOptions)
+export class PostalAddressEntity {
+  @PrimaryGeneratedColumn({ name: 'address_id', type: 'integer' })
+  public addressId!: number;
+
+  @Column({ name: 'line1', type: 'varchar', length: 255 })
+  public line1!: string;
+
+  @Column({ name: 'line2', type: 'varchar', length: 255, nullable: true })
+  public line2?: string | null;
+
+  @Column({ name: 'city', type: 'varchar', length: 120 })
+  public city!: string;
+
+  @Column({ name: 'state', type: 'varchar', length: 80 })
+  public state!: string;
+
+  @Column({ name: 'postal_code', type: 'varchar', length: 20 })
+  public postalCode!: string;
+
+  @Column({ name: 'country', type: 'char', length: 2 })
+  public country!: string;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  public createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamptz' })
+  public updatedAt!: Date;
+
+  @OneToMany(() => CustomerEntity, (customer) => customer.address)
+  public customers?: CustomerEntity[];
+}

--- a/api/src/customer/entities/privacy_settings.entity.ts
+++ b/api/src/customer/entities/privacy_settings.entity.ts
@@ -1,0 +1,48 @@
+/**
+ * App: Customer Registration
+ * Package: api/src/customer/entities
+ * File: privacy_settings.entity.ts
+ * Version: 0.1.1
+ * Turns: 3
+ * Author: Codex Agent
+ * Date: 2025-09-25T19:36:06Z
+ * Exports: PrivacySettingsEntity
+ * Description: Maps the privacy_settings table capturing customer communication and security preferences.
+ */
+import type { EntityOptions } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { CustomerEntity } from './customer.entity';
+
+const schemaName = process.env.DATABASE_SCHEMA;
+const entityOptions: EntityOptions = {
+  name: 'privacy_settings',
+  ...(schemaName ? { schema: schemaName } : {}),
+};
+
+@Entity(entityOptions)
+export class PrivacySettingsEntity {
+  @PrimaryGeneratedColumn({ name: 'privacy_settings_id', type: 'integer' })
+  public privacySettingsId!: number;
+
+  @Column({ name: 'marketing_emails_enabled', type: 'boolean' })
+  public marketingEmailsEnabled!: boolean;
+
+  @Column({ name: 'two_factor_enabled', type: 'boolean' })
+  public twoFactorEnabled!: boolean;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  public createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamptz' })
+  public updatedAt!: Date;
+
+  @OneToMany(() => CustomerEntity, (customer) => customer.privacySettings)
+  public customers?: CustomerEntity[];
+}

--- a/api/src/customer/services/customer.service.ts
+++ b/api/src/customer/services/customer.service.ts
@@ -1,0 +1,304 @@
+/**
+ * App: Customer Registration
+ * Package: api/src/customer/services
+ * File: customer.service.ts
+ * Version: 0.1.1
+ * Turns: 3
+ * Author: Codex Agent
+ * Date: 2025-09-25T19:36:06Z
+ * Exports: CustomerService, CreateCustomerInput, UpdateCustomerInput
+ * Description: Provides repository-backed persistence operations for the customer domain aggregates and projections.
+ */
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import { CustomerEntity } from '../entities/customer.entity';
+import { CustomerEmailEntity } from '../entities/customer_email.entity';
+import { CustomerPhoneNumberEntity } from '../entities/customer_phone_number.entity';
+import { CustomerProfileView } from '../entities/customer_profile_view.entity';
+import { PostalAddressEntity } from '../entities/postal_address.entity';
+import { PrivacySettingsEntity } from '../entities/privacy_settings.entity';
+
+type CreatePostalAddressInput = {
+  line1: string;
+  line2?: string | null;
+  city: string;
+  state: string;
+  postalCode: string;
+  country: string;
+};
+
+type CreatePrivacySettingsInput = {
+  marketingEmailsEnabled: boolean;
+  twoFactorEnabled: boolean;
+};
+
+type CreateCustomerEmailInput = {
+  email: string;
+  isPrimary: boolean;
+};
+
+type CreateCustomerPhoneInput = {
+  type: string;
+  number: string;
+  extension?: string | null;
+};
+
+export type CreateCustomerInput = {
+  customerId?: string;
+  name: string;
+  firstName: string;
+  middleName?: string | null;
+  lastName: string;
+  email: string;
+  addressId?: number;
+  privacySettingsId?: number;
+  address?: CreatePostalAddressInput;
+  privacySettings?: CreatePrivacySettingsInput;
+  emails?: CreateCustomerEmailInput[];
+  phoneNumbers?: CreateCustomerPhoneInput[];
+};
+
+export type UpdateCustomerInput = Partial<Omit<CreateCustomerInput, 'customerId'>> & {
+  address?: CreatePostalAddressInput | null;
+  privacySettings?: CreatePrivacySettingsInput | null;
+  emails?: CreateCustomerEmailInput[] | null;
+  phoneNumbers?: CreateCustomerPhoneInput[] | null;
+};
+
+@Injectable()
+export class CustomerService {
+  public constructor(
+    @InjectRepository(CustomerEntity)
+    private readonly customerRepository: Repository<CustomerEntity>,
+    @InjectRepository(CustomerEmailEntity)
+    private readonly customerEmailRepository: Repository<CustomerEmailEntity>,
+    @InjectRepository(CustomerPhoneNumberEntity)
+    private readonly customerPhoneRepository: Repository<CustomerPhoneNumberEntity>,
+    @InjectRepository(PostalAddressEntity)
+    private readonly addressRepository: Repository<PostalAddressEntity>,
+    @InjectRepository(PrivacySettingsEntity)
+    private readonly privacyRepository: Repository<PrivacySettingsEntity>,
+    @InjectRepository(CustomerProfileView)
+    private readonly profileRepository: Repository<CustomerProfileView>,
+  ) {}
+
+  public async createCustomer(input: CreateCustomerInput): Promise<CustomerEntity> {
+    return this.customerRepository.manager.transaction(async (entityManager) => {
+      const address = input.address
+        ? await entityManager.getRepository(PostalAddressEntity).save(
+            this.addressRepository.create({
+              line1: input.address.line1,
+              line2: input.address.line2 ?? null,
+              city: input.address.city,
+              state: input.address.state,
+              postalCode: input.address.postalCode,
+              country: input.address.country,
+            }),
+          )
+        : undefined;
+
+      const privacy = input.privacySettings
+        ? await entityManager.getRepository(PrivacySettingsEntity).save(
+            this.privacyRepository.create({
+              marketingEmailsEnabled: input.privacySettings.marketingEmailsEnabled,
+              twoFactorEnabled: input.privacySettings.twoFactorEnabled,
+            }),
+          )
+        : undefined;
+
+      const customer = this.customerRepository.create({
+        name: input.name,
+        firstName: input.firstName,
+        middleName: input.middleName ?? null,
+        lastName: input.lastName,
+        email: input.email,
+      });
+
+      if (input.customerId) {
+        customer.customerId = input.customerId;
+      }
+
+      customer.addressId = address?.addressId ?? input.addressId ?? null;
+      customer.privacySettingsId = privacy?.privacySettingsId ?? input.privacySettingsId ?? null;
+
+      const savedCustomer: CustomerEntity = await entityManager
+        .getRepository(CustomerEntity)
+        .save(customer);
+
+      if (input.emails?.length) {
+        const emailEntities = input.emails.map((email) =>
+          this.customerEmailRepository.create({
+            customerId: savedCustomer.customerId,
+            email: email.email,
+            isPrimary: email.isPrimary,
+          }),
+        );
+        await entityManager.getRepository(CustomerEmailEntity).save(emailEntities);
+      }
+
+      if (input.phoneNumbers?.length) {
+        const phoneEntities = input.phoneNumbers.map((phone) =>
+          this.customerPhoneRepository.create({
+            customerId: savedCustomer.customerId,
+            type: phone.type,
+            number: phone.number,
+            extension: phone.extension ?? null,
+          }),
+        );
+        await entityManager.getRepository(CustomerPhoneNumberEntity).save(phoneEntities);
+      }
+
+      const reloaded = await entityManager.getRepository(CustomerEntity).findOne({
+        where: { customerId: savedCustomer.customerId },
+        relations: {
+          address: true,
+          privacySettings: true,
+          emails: true,
+          phoneNumbers: true,
+        },
+      });
+
+      if (!reloaded) {
+        throw new Error('Failed to reload persisted customer record.');
+      }
+
+      return reloaded;
+    });
+  }
+
+  public async findCustomerById(customerId: string): Promise<CustomerEntity | null> {
+    return this.customerRepository.findOne({
+      where: { customerId },
+      relations: {
+        address: true,
+        privacySettings: true,
+        emails: true,
+        phoneNumbers: true,
+      },
+    });
+  }
+
+  public async listCustomerProfiles(customerIds?: string[]): Promise<CustomerProfileView[]> {
+    if (!customerIds?.length) {
+      return this.profileRepository.find();
+    }
+    return this.profileRepository.find({ where: { customerId: In(customerIds) } });
+  }
+
+  public async updateCustomer(customerId: string, updates: UpdateCustomerInput): Promise<CustomerEntity> {
+    return this.customerRepository.manager.transaction(async (entityManager) => {
+      const repository = entityManager.getRepository(CustomerEntity);
+      const existing = await repository.findOne({ where: { customerId } });
+      if (!existing) {
+        throw new NotFoundException(`Customer ${customerId} was not found.`);
+      }
+
+      if (updates.address === null) {
+        existing.addressId = null;
+      } else if (updates.address) {
+        const address = await entityManager.getRepository(PostalAddressEntity).save(
+          this.addressRepository.create({
+            line1: updates.address.line1,
+            line2: updates.address.line2 ?? null,
+            city: updates.address.city,
+            state: updates.address.state,
+            postalCode: updates.address.postalCode,
+            country: updates.address.country,
+          }),
+        );
+        existing.addressId = address.addressId;
+      } else if (updates.addressId !== undefined) {
+        existing.addressId = updates.addressId;
+      }
+
+      if (updates.privacySettings === null) {
+        existing.privacySettingsId = null;
+      } else if (updates.privacySettings) {
+        const privacy = await entityManager.getRepository(PrivacySettingsEntity).save(
+          this.privacyRepository.create({
+            marketingEmailsEnabled: updates.privacySettings.marketingEmailsEnabled,
+            twoFactorEnabled: updates.privacySettings.twoFactorEnabled,
+          }),
+        );
+        existing.privacySettingsId = privacy.privacySettingsId;
+      } else if (updates.privacySettingsId !== undefined) {
+        existing.privacySettingsId = updates.privacySettingsId;
+      }
+
+      if (updates.name !== undefined) {
+        existing.name = updates.name;
+      }
+      if (updates.firstName !== undefined) {
+        existing.firstName = updates.firstName;
+      }
+      if (updates.middleName !== undefined) {
+        existing.middleName = updates.middleName;
+      }
+      if (updates.lastName !== undefined) {
+        existing.lastName = updates.lastName;
+      }
+      if (updates.email !== undefined) {
+        existing.email = updates.email;
+      }
+
+      await repository.save(existing);
+
+      if (updates.emails) {
+        await entityManager.getRepository(CustomerEmailEntity).delete({ customerId });
+        if (updates.emails.length) {
+          const emailEntities = updates.emails.map((email) =>
+            this.customerEmailRepository.create({
+              customerId,
+              email: email.email,
+              isPrimary: email.isPrimary,
+            }),
+          );
+          await entityManager.getRepository(CustomerEmailEntity).save(emailEntities);
+        }
+      }
+
+      if (updates.phoneNumbers) {
+        await entityManager.getRepository(CustomerPhoneNumberEntity).delete({ customerId });
+        if (updates.phoneNumbers.length) {
+          const phoneEntities = updates.phoneNumbers.map((phone) =>
+            this.customerPhoneRepository.create({
+              customerId,
+              type: phone.type,
+              number: phone.number,
+              extension: phone.extension ?? null,
+            }),
+          );
+          await entityManager.getRepository(CustomerPhoneNumberEntity).save(phoneEntities);
+        }
+      }
+
+      const reloaded = await repository.findOne({
+        where: { customerId },
+        relations: {
+          address: true,
+          privacySettings: true,
+          emails: true,
+          phoneNumbers: true,
+        },
+      });
+
+      if (!reloaded) {
+        throw new Error(`Customer ${customerId} could not be reloaded after update.`);
+      }
+
+      return reloaded;
+    });
+  }
+
+  public async removeCustomer(customerId: string): Promise<void> {
+    await this.customerRepository.manager.transaction(async (entityManager) => {
+      const repository = entityManager.getRepository(CustomerEntity);
+      const existing = await repository.findOne({ where: { customerId } });
+      if (!existing) {
+        throw new NotFoundException(`Customer ${customerId} was not found.`);
+      }
+      await repository.delete(customerId);
+    });
+  }
+}

--- a/api/src/database/data-source.ts
+++ b/api/src/database/data-source.ts
@@ -1,0 +1,120 @@
+/**
+ * App: Customer Registration
+ * Package: api/src/database
+ * File: data-source.ts
+ * Version: 0.1.3
+ * Turns: 3
+ * Author: Codex Agent
+ * Date: 2025-09-25T19:36:06Z
+ * Exports: AppDataSource, getDataSourceOptions
+ * Description: Configures the shared TypeORM DataSource using environment variables from ai/context/.env.
+ */
+import 'reflect-metadata';
+import * as path from 'node:path';
+import * as dotenv from 'dotenv';
+import type { DataSourceOptions } from 'typeorm';
+import { DataSource } from 'typeorm';
+import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
+import { CustomerEntity } from '../customer/entities/customer.entity';
+import { CustomerEmailEntity } from '../customer/entities/customer_email.entity';
+import { CustomerPhoneNumberEntity } from '../customer/entities/customer_phone_number.entity';
+import { PostalAddressEntity } from '../customer/entities/postal_address.entity';
+import { PrivacySettingsEntity } from '../customer/entities/privacy_settings.entity';
+import { CustomerProfileView } from '../customer/entities/customer_profile_view.entity';
+
+dotenv.config({ path: path.resolve(__dirname, '..', '..', '..', 'ai', 'context', '.env') });
+
+const REQUIRED_ENV_VARS = [
+  'DATABASE_HOST',
+  'DATABASE_PORT',
+  'DATABASE_USERNAME',
+  'DATABASE_PASSWORD',
+  'DATABASE_NAME',
+];
+
+const OPTIONAL_ENV_VARS = ['DATABASE_SCHEMA', 'DATABASE_SSL'];
+
+type EnvValueOptions = {
+  fallback?: string;
+  optional?: boolean;
+};
+
+function getEnv(name: string, options: EnvValueOptions = {}): string {
+  const value = process.env[name];
+  if ((value === undefined || value === '') && !options.optional) {
+    throw new Error(
+      `Database configuration is incomplete. Missing ${name}. Ensure it exists in ai/context/.env`,
+    );
+  }
+  return value ?? options.fallback ?? '';
+}
+
+function getInt(name: string, fallback?: number): number {
+  const value = process.env[name];
+  if (value === undefined || value === '') {
+    if (fallback !== undefined) {
+      return fallback;
+    }
+    throw new Error(
+      `Database configuration is incomplete. Missing ${name}. Ensure it exists in ai/context/.env`,
+    );
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed)) {
+    throw new Error(`${name} must be an integer but received "${value}".`);
+  }
+  return parsed;
+}
+
+function getBool(name: string, fallback = false): boolean {
+  const value = process.env[name];
+  if (value === undefined || value === '') {
+    return fallback;
+  }
+  return value.toLowerCase() === 'true';
+}
+
+export function getDataSourceOptions(): DataSourceOptions {
+  REQUIRED_ENV_VARS.forEach((key) => getEnv(key));
+  OPTIONAL_ENV_VARS.forEach((key) => getEnv(key, { optional: true }));
+
+  const schema = getEnv('DATABASE_SCHEMA', { optional: true });
+  const sslEnabled = getBool('DATABASE_SSL');
+  const isCompiled = __filename.endsWith('.js');
+
+  const options: DataSourceOptions = {
+    type: 'postgres',
+    host: getEnv('DATABASE_HOST'),
+    port: getInt('DATABASE_PORT'),
+    username: getEnv('DATABASE_USERNAME'),
+    password: getEnv('DATABASE_PASSWORD'),
+    database: getEnv('DATABASE_NAME'),
+    synchronize: false,
+    logging: false,
+    namingStrategy: new SnakeNamingStrategy(),
+    entities: [
+      PostalAddressEntity,
+      PrivacySettingsEntity,
+      CustomerEntity,
+      CustomerEmailEntity,
+      CustomerPhoneNumberEntity,
+      CustomerProfileView,
+    ],
+    migrations: [
+      isCompiled
+        ? path.resolve(__dirname, '..', 'migrations', '*.js')
+        : path.resolve(__dirname, '..', 'migrations', '*.ts'),
+    ],
+  };
+
+  if (schema) {
+    (options as { schema?: string }).schema = schema;
+  }
+  if (sslEnabled) {
+    (options as { ssl?: boolean | Record<string, unknown> }).ssl = { rejectUnauthorized: false };
+  }
+
+  return options;
+}
+
+export const AppDataSource = new DataSource(getDataSourceOptions());

--- a/api/src/database/validate-connection.ts
+++ b/api/src/database/validate-connection.ts
@@ -1,0 +1,26 @@
+/**
+ * App: Customer Registration
+ * Package: api/src/database
+ * File: validate-connection.ts
+ * Version: 0.1.0
+ * Turns: 3
+ * Author: Codex Agent
+ * Date: 2025-09-25T19:36:06Z
+ * Exports: (none)
+ * Description: Verifies that the TypeORM DataSource can connect to the configured database.
+ */
+import { AppDataSource } from './data-source';
+
+void (async () => {
+  try {
+    const dataSource = await AppDataSource.initialize();
+    await dataSource.query('SELECT 1');
+    await dataSource.destroy();
+     
+    console.log('DB connection OK');
+  } catch (error) {
+     
+    console.error('DB connection failed', error);
+    process.exitCode = 1;
+  }
+})();

--- a/api/src/migrations/20250925193600-CreateCustomerDomainSchema.ts
+++ b/api/src/migrations/20250925193600-CreateCustomerDomainSchema.ts
@@ -1,0 +1,280 @@
+/**
+ * App: Customer Registration
+ * Package: api/src/migrations
+ * File: 20250925193600-CreateCustomerDomainSchema.ts
+ * Version: 0.1.3
+ * Turns: 3
+ * Author: Codex Agent
+ * Date: 2025-09-25T19:36:06Z
+ * Exports: CreateCustomerDomainSchema1695660960
+ * Description: Establishes customer domain tables, relationships, and projection view required by the service layer.
+ */
+import type { DataSourceOptions, MigrationInterface, QueryRunner } from 'typeorm';
+import { Table, TableForeignKey, TableIndex, TableUnique } from 'typeorm';
+
+function resolveSchema(queryRunner: QueryRunner): string | undefined {
+  const options = queryRunner.connection.options as DataSourceOptions & { schema?: string };
+  if (options.schema && options.schema.length > 0) {
+    return options.schema;
+  }
+  if (process.env.DATABASE_SCHEMA && process.env.DATABASE_SCHEMA.length > 0) {
+    return process.env.DATABASE_SCHEMA;
+  }
+  return undefined;
+}
+
+function tablePath(schema: string | undefined, identifier: string): string {
+  return schema ? `${schema}.${identifier}` : identifier;
+}
+
+function withSchema(schema: string | undefined, identifier: string): string {
+  return schema ? `"${schema}"."${identifier}"` : `"${identifier}"`;
+}
+
+export class CreateCustomerDomainSchema1695660960 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const schema = resolveSchema(queryRunner);
+    const driverType = (queryRunner.connection.options as { type?: string }).type ?? 'postgres';
+    const timestampType = driverType === 'postgres' ? 'timestamptz' : 'timestamp';
+
+    if (schema && driverType === 'postgres') {
+      await queryRunner.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`);
+    }
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'postal_addresses',
+        columns: [
+          {
+            name: 'address_id',
+            type: 'integer',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          { name: 'line1', type: 'varchar', length: '255', isNullable: false },
+          { name: 'line2', type: 'varchar', length: '255', isNullable: true },
+          { name: 'city', type: 'varchar', length: '120', isNullable: false },
+          { name: 'state', type: 'varchar', length: '80', isNullable: false },
+          { name: 'postal_code', type: 'varchar', length: '20', isNullable: false },
+          { name: 'country', type: 'char', length: '2', isNullable: false },
+          { name: 'created_at', type: timestampType, default: 'CURRENT_TIMESTAMP', isNullable: false },
+          {
+            name: 'updated_at',
+            type: timestampType,
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+        ],
+        ...(schema ? { schema } : {}),
+      }),
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'privacy_settings',
+        columns: [
+          {
+            name: 'privacy_settings_id',
+            type: 'integer',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          { name: 'marketing_emails_enabled', type: 'boolean', isNullable: false },
+          { name: 'two_factor_enabled', type: 'boolean', isNullable: false },
+          { name: 'created_at', type: timestampType, default: 'CURRENT_TIMESTAMP', isNullable: false },
+          {
+            name: 'updated_at',
+            type: timestampType,
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+        ],
+        ...(schema ? { schema } : {}),
+      }),
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'customers',
+        columns: [
+          {
+            name: 'customer_id',
+            type: 'uuid',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'uuid',
+          },
+          { name: 'name', type: 'varchar', length: '255', isNullable: false },
+          { name: 'first_name', type: 'varchar', length: '120', isNullable: false },
+          { name: 'middle_name', type: 'varchar', length: '120', isNullable: true },
+          { name: 'last_name', type: 'varchar', length: '120', isNullable: false },
+          { name: 'email', type: 'varchar', length: '255', isNullable: false },
+          { name: 'address_id', type: 'integer', isNullable: true },
+          { name: 'privacy_settings_id', type: 'integer', isNullable: true },
+          { name: 'created_at', type: timestampType, default: 'CURRENT_TIMESTAMP', isNullable: false },
+          {
+            name: 'updated_at',
+            type: timestampType,
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+        ],
+        uniques: [new TableUnique({ name: 'ux_customers_email', columnNames: ['email'] })],
+        indices: [
+          new TableIndex({ name: 'ix_customers_address_id', columnNames: ['address_id'] }),
+          new TableIndex({ name: 'ix_customers_privacy_settings_id', columnNames: ['privacy_settings_id'] }),
+        ],
+        ...(schema ? { schema } : {}),
+      }),
+    );
+
+    await queryRunner.createForeignKeys(
+      tablePath(schema, 'customers'),
+      [
+        new TableForeignKey({
+          name: 'fk_customers_address_id',
+          columnNames: ['address_id'],
+          referencedTableName: 'postal_addresses',
+          referencedColumnNames: ['address_id'],
+          onDelete: 'SET NULL',
+          ...(schema ? { referencedSchema: schema } : {}),
+        }),
+        new TableForeignKey({
+          name: 'fk_customers_privacy_settings_id',
+          columnNames: ['privacy_settings_id'],
+          referencedTableName: 'privacy_settings',
+          referencedColumnNames: ['privacy_settings_id'],
+          onDelete: 'SET NULL',
+          ...(schema ? { referencedSchema: schema } : {}),
+        }),
+      ],
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'customer_emails',
+        columns: [
+          {
+            name: 'email_id',
+            type: 'integer',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          { name: 'customer_id', type: 'uuid', isNullable: false },
+          { name: 'email', type: 'varchar', length: '255', isNullable: false },
+          { name: 'is_primary', type: 'boolean', isNullable: false },
+          { name: 'created_at', type: timestampType, default: 'CURRENT_TIMESTAMP', isNullable: false },
+        ],
+        uniques: [
+          new TableUnique({
+            name: 'ux_customer_emails_customer_id_email',
+            columnNames: ['customer_id', 'email'],
+          }),
+        ],
+        indices: [
+          new TableIndex({ name: 'ix_customer_emails_customer_id', columnNames: ['customer_id'] }),
+        ],
+        ...(schema ? { schema } : {}),
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      tablePath(schema, 'customer_emails'),
+      new TableForeignKey({
+        name: 'fk_customer_emails_customer_id',
+        columnNames: ['customer_id'],
+        referencedTableName: 'customers',
+        referencedColumnNames: ['customer_id'],
+        onDelete: 'CASCADE',
+        ...(schema ? { referencedSchema: schema } : {}),
+      }),
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'customer_phone_numbers',
+        columns: [
+          {
+            name: 'phone_id',
+            type: 'integer',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          { name: 'customer_id', type: 'uuid', isNullable: false },
+          { name: 'type', type: 'varchar', length: '20', isNullable: false },
+          { name: 'number', type: 'varchar', length: '20', isNullable: false },
+          { name: 'extension', type: 'varchar', length: '10', isNullable: true },
+          { name: 'created_at', type: timestampType, default: 'CURRENT_TIMESTAMP', isNullable: false },
+        ],
+        uniques: [
+          new TableUnique({
+            name: 'ux_customer_phone_numbers_customer_id_type_number',
+            columnNames: ['customer_id', 'type', 'number'],
+          }),
+        ],
+        indices: [
+          new TableIndex({ name: 'ix_customer_phone_numbers_customer_id', columnNames: ['customer_id'] }),
+        ],
+        ...(schema ? { schema } : {}),
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      tablePath(schema, 'customer_phone_numbers'),
+      new TableForeignKey({
+        name: 'fk_customer_phone_numbers_customer_id',
+        columnNames: ['customer_id'],
+        referencedTableName: 'customers',
+        referencedColumnNames: ['customer_id'],
+        onDelete: 'CASCADE',
+        ...(schema ? { referencedSchema: schema } : {}),
+      }),
+    );
+
+    const viewName = withSchema(schema, 'customer_profile_view');
+    const customers = withSchema(schema, 'customers');
+    const addresses = withSchema(schema, 'postal_addresses');
+    const privacy = withSchema(schema, 'privacy_settings');
+
+    await queryRunner.query(
+      `CREATE VIEW ${viewName} AS
+      SELECT
+        c.customer_id,
+        c.name,
+        c.first_name,
+        c.middle_name,
+        c.last_name,
+        c.email,
+        a.line1,
+        a.line2,
+        a.city,
+        a.state,
+        a.postal_code,
+        a.country,
+        p.marketing_emails_enabled,
+        p.two_factor_enabled
+      FROM ${customers} c
+      LEFT JOIN ${addresses} a ON a.address_id = c.address_id
+      LEFT JOIN ${privacy} p ON p.privacy_settings_id = c.privacy_settings_id`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const schema = resolveSchema(queryRunner);
+    const viewName = withSchema(schema, 'customer_profile_view');
+
+    await queryRunner.query(`DROP VIEW IF EXISTS ${viewName}`);
+    await queryRunner.dropTable(tablePath(schema, 'customer_phone_numbers'));
+    await queryRunner.dropTable(tablePath(schema, 'customer_emails'));
+    await queryRunner.dropTable(tablePath(schema, 'customers'));
+    await queryRunner.dropTable(tablePath(schema, 'privacy_settings'));
+    await queryRunner.dropTable(tablePath(schema, 'postal_addresses'));
+  }
+}

--- a/changelog.md
+++ b/changelog.md
@@ -9,3 +9,8 @@
 - Added a customer_domain migration that creates normalized tables, foreign keys, indexes, and a flattened reporting view.
 - Generated the Draft 2020-12 customer_domain entity schema reflecting the persisted model for integrations.
 - Authored idempotent test data seeding script and documented migration workflows in `db/README.md`.
+
+## 0.3.0 – 2025-09-25T19:49:54Z (Turn 3)
+- Configured a shared TypeORM data source, CLI scripts, and validation utilities that read credentials from `ai/context/.env`.
+- Implemented customer domain entities, view projections, and a transactional NestJS service bundled in a new `CustomerModule`.
+- Captured the initial TypeORM migration and README guidance to manage migrations and runtime database checks.


### PR DESCRIPTION
# Summary
Configure a shared TypeORM data source, customer persistence layer, and supporting migrations for the API.

# Details
* **What was added/changed?**
  * Added an environment-driven `AppDataSource`, connection validation script, and TypeORM CLI workflows with supporting documentation.
  * Implemented customer domain entities, view projection, NestJS module, and transactional service wired into the application module.
  * Authored the initial TypeORM migration for the customer schema and updated the project changelog.
* **Why was it needed?**
  * To provide a single source of truth for TypeORM configuration and enable repository-backed persistence for the customer domain.
* **How was it implemented?** (key design points)
  * Loads configuration from `ai/context/.env`, applies the snake-case naming strategy, and exposes build-aware migration globs reused by NestJS and the CLI.
  * Creates TypeORM entities and a service that persist related records within transactions, exposing them through a dedicated `CustomerModule`.
  * Generates a migration that creates the schema, tables, constraints, and view defined by the domain specification.

# Related Tasks
- TASK 06 - Create TypeORM Configuration
- TASK 07 — Create Domain Entities

# Checklist
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Linter passes
- [x] Documentation updated

# Breaking Changes
None

# Codex Task Link
execute turn 3

------
https://chatgpt.com/codex/tasks/task_e_68d599102640832d98540331a1e3a5d7