### PR TITLE
feat: add customer domain migration artifacts

### DIFF
--- a/api/src/customer/entities/customer.entity.ts
+++ b/api/src/customer/entities/customer.entity.ts
@@ -1,0 +1,155 @@
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryColumn,
+  PrimaryGeneratedColumn,
+  Unique,
+} from 'typeorm';
+
+@Entity({ name: 'postal_addresses', schema: 'customer_domain' })
+export class PostalAddressEntity {
+  @PrimaryGeneratedColumn({ type: 'integer', name: 'address_id' })
+  addressId!: number;
+
+  @Column({ type: 'varchar', name: 'line1', length: 255 })
+  line1!: string;
+
+  @Column({ type: 'varchar', name: 'line2', length: 255, nullable: true })
+  line2: string | null = null;
+
+  @Column({ type: 'varchar', name: 'city', length: 100 })
+  city!: string;
+
+  @Column({ type: 'varchar', name: 'state', length: 100 })
+  state!: string;
+
+  @Column({ type: 'varchar', name: 'postal_code', length: 20 })
+  postalCode!: string;
+
+  @Column({ type: 'varchar', name: 'country', length: 2 })
+  country!: string;
+
+  @OneToMany(() => CustomerEntity, (customer) => customer.address)
+  customers?: CustomerEntity[];
+}
+
+@Entity({ name: 'privacy_settings', schema: 'customer_domain' })
+export class PrivacySettingsEntity {
+  @PrimaryGeneratedColumn({ type: 'integer', name: 'privacy_settings_id' })
+  privacySettingsId!: number;
+
+  @Column({ type: 'boolean', name: 'marketing_emails_enabled' })
+  marketingEmailsEnabled!: boolean;
+
+  @Column({ type: 'boolean', name: 'two_factor_enabled' })
+  twoFactorEnabled!: boolean;
+
+  @OneToMany(() => CustomerEntity, (customer) => customer.privacySettings)
+  customers?: CustomerEntity[];
+}
+
+@Index('ix_customers__address_id', ['addressId'])
+@Index('ix_customers__privacy_settings_id', ['privacySettingsId'])
+@Entity({ name: 'customers', schema: 'customer_domain' })
+export class CustomerEntity {
+  @PrimaryColumn('uuid', { name: 'customer_id', default: () => 'gen_random_uuid()' })
+  customerId!: string;
+
+  @Column({ type: 'varchar', name: 'first_name', length: 255 })
+  firstName!: string;
+
+  @Column({ type: 'varchar', name: 'middle_name', length: 255, nullable: true })
+  middleName: string | null = null;
+
+  @Column({ type: 'varchar', name: 'last_name', length: 255 })
+  lastName!: string;
+
+  @Column({ type: 'integer', name: 'address_id', nullable: true })
+  addressId: number | null = null;
+
+  @Column({ type: 'integer', name: 'privacy_settings_id', nullable: true })
+  privacySettingsId: number | null = null;
+
+  @Column({ type: 'timestamptz', name: 'created_at', default: () => 'now()' })
+  createdAt!: Date;
+
+  @Column({ type: 'timestamptz', name: 'updated_at', default: () => 'now()' })
+  updatedAt!: Date;
+
+  @ManyToOne(() => PostalAddressEntity, (address) => address.customers, {
+    nullable: true,
+    onDelete: 'SET NULL',
+  })
+  @JoinColumn({ name: 'address_id', referencedColumnName: 'addressId' })
+  address?: PostalAddressEntity | null;
+
+  @ManyToOne(() => PrivacySettingsEntity, (settings) => settings.customers, {
+    nullable: true,
+    onDelete: 'SET NULL',
+  })
+  @JoinColumn({ name: 'privacy_settings_id', referencedColumnName: 'privacySettingsId' })
+  privacySettings?: PrivacySettingsEntity | null;
+
+  @OneToMany(() => CustomerEmailEntity, (email) => email.customer)
+  emails?: CustomerEmailEntity[];
+
+  @OneToMany(() => CustomerPhoneNumberEntity, (phone) => phone.customer)
+  phoneNumbers?: CustomerPhoneNumberEntity[];
+}
+
+@Unique('uq_customer_emails__customer_id_email', ['customerId', 'email'])
+@Index('ix_customer_emails__customer_id', ['customerId'])
+@Index('idx_customer_email_primary', ['customerId'], { where: '"is_primary" IS TRUE' })
+@Entity({ name: 'customer_emails', schema: 'customer_domain' })
+export class CustomerEmailEntity {
+  @PrimaryGeneratedColumn({ type: 'integer', name: 'email_id' })
+  emailId!: number;
+
+  @Column({ type: 'uuid', name: 'customer_id' })
+  customerId!: string;
+
+  @Column({ type: 'varchar', name: 'email', length: 320 })
+  email!: string;
+
+  @Column({ type: 'boolean', name: 'is_primary' })
+  isPrimary!: boolean;
+
+  @Column({ type: 'timestamptz', name: 'created_at', default: () => 'now()' })
+  createdAt!: Date;
+
+  @ManyToOne(() => CustomerEntity, (customer) => customer.emails, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'customer_id', referencedColumnName: 'customerId' })
+  customer!: CustomerEntity;
+}
+
+@Unique('uq_customer_phone_numbers__customer_id_number', ['customerId', 'number'])
+@Index('ix_customer_phone_numbers__customer_id', ['customerId'])
+@Entity({ name: 'customer_phone_numbers', schema: 'customer_domain' })
+export class CustomerPhoneNumberEntity {
+  @PrimaryGeneratedColumn({ type: 'integer', name: 'phone_id' })
+  phoneId!: number;
+
+  @Column({ type: 'uuid', name: 'customer_id' })
+  customerId!: string;
+
+  @Column({ type: 'varchar', name: 'type', length: 20 })
+  kind!: string;
+
+  @Column({ type: 'varchar', name: 'number', length: 20 })
+  phoneNumber!: string;
+
+  @Column({ type: 'timestamptz', name: 'created_at', default: () => 'now()' })
+  createdAt!: Date;
+
+  @ManyToOne(() => CustomerEntity, (customer) => customer.phoneNumbers, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'customer_id', referencedColumnName: 'customerId' })
+  customer!: CustomerEntity;
+}

--- a/api/src/migrations/20250928183335-customer.ts
+++ b/api/src/migrations/20250928183335-customer.ts
@@ -1,0 +1,325 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+  TableIndex,
+  TableUnique,
+} from 'typeorm';
+
+export class CustomerDomainSchema20250928183335 implements MigrationInterface {
+  name = 'CustomerDomainSchema20250928183335';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createSchema('customer_domain', true);
+
+    await queryRunner.createTable(
+      new Table({
+        schema: 'customer_domain',
+        name: 'postal_addresses',
+        columns: [
+          {
+            name: 'address_id',
+            type: 'integer',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'line1',
+            type: 'varchar',
+            length: '255',
+            isNullable: false,
+          },
+          {
+            name: 'line2',
+            type: 'varchar',
+            length: '255',
+            isNullable: true,
+          },
+          {
+            name: 'city',
+            type: 'varchar',
+            length: '100',
+            isNullable: false,
+          },
+          {
+            name: 'state',
+            type: 'varchar',
+            length: '100',
+            isNullable: false,
+          },
+          {
+            name: 'postal_code',
+            type: 'varchar',
+            length: '20',
+            isNullable: false,
+          },
+          {
+            name: 'country',
+            type: 'varchar',
+            length: '2',
+            isNullable: false,
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        schema: 'customer_domain',
+        name: 'privacy_settings',
+        columns: [
+          {
+            name: 'privacy_settings_id',
+            type: 'integer',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'marketing_emails_enabled',
+            type: 'boolean',
+            isNullable: false,
+          },
+          {
+            name: 'two_factor_enabled',
+            type: 'boolean',
+            isNullable: false,
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        schema: 'customer_domain',
+        name: 'customers',
+        columns: [
+          {
+            name: 'customer_id',
+            type: 'uuid',
+            isPrimary: true,
+            default: () => 'gen_random_uuid()',
+          },
+          {
+            name: 'first_name',
+            type: 'varchar',
+            length: '255',
+            isNullable: false,
+          },
+          {
+            name: 'middle_name',
+            type: 'varchar',
+            length: '255',
+            isNullable: true,
+          },
+          {
+            name: 'last_name',
+            type: 'varchar',
+            length: '255',
+            isNullable: false,
+          },
+          {
+            name: 'address_id',
+            type: 'integer',
+            isNullable: true,
+          },
+          {
+            name: 'privacy_settings_id',
+            type: 'integer',
+            isNullable: true,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamptz',
+            isNullable: false,
+            default: () => 'now()',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamptz',
+            isNullable: false,
+            default: () => 'now()',
+          },
+        ],
+        foreignKeys: [
+          new TableForeignKey({
+            name: 'fk_customers__postal_addresses__address_id',
+            columnNames: ['address_id'],
+            referencedSchema: 'customer_domain',
+            referencedTableName: 'postal_addresses',
+            referencedColumnNames: ['address_id'],
+            onDelete: 'SET NULL',
+          }),
+          new TableForeignKey({
+            name: 'fk_customers__privacy_settings__privacy_settings_id',
+            columnNames: ['privacy_settings_id'],
+            referencedSchema: 'customer_domain',
+            referencedTableName: 'privacy_settings',
+            referencedColumnNames: ['privacy_settings_id'],
+            onDelete: 'SET NULL',
+          }),
+        ],
+        indices: [
+          new TableIndex({
+            name: 'ix_customers__address_id',
+            columnNames: ['address_id'],
+          }),
+          new TableIndex({
+            name: 'ix_customers__privacy_settings_id',
+            columnNames: ['privacy_settings_id'],
+          }),
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        schema: 'customer_domain',
+        name: 'customer_emails',
+        columns: [
+          {
+            name: 'email_id',
+            type: 'integer',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'customer_id',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'email',
+            type: 'varchar',
+            length: '320',
+            isNullable: false,
+          },
+          {
+            name: 'is_primary',
+            type: 'boolean',
+            isNullable: false,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamptz',
+            isNullable: false,
+            default: () => 'now()',
+          },
+        ],
+        uniques: [
+          new TableUnique({
+            name: 'uq_customer_emails__customer_id_email',
+            columnNames: ['customer_id', 'email'],
+          }),
+        ],
+        foreignKeys: [
+          new TableForeignKey({
+            name: 'fk_customer_emails__customers__customer_id',
+            columnNames: ['customer_id'],
+            referencedSchema: 'customer_domain',
+            referencedTableName: 'customers',
+            referencedColumnNames: ['customer_id'],
+            onDelete: 'CASCADE',
+          }),
+        ],
+        indices: [
+          new TableIndex({
+            name: 'ix_customer_emails__customer_id',
+            columnNames: ['customer_id'],
+          }),
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'customer_domain.customer_emails',
+      new TableIndex({
+        name: 'idx_customer_email_primary',
+        columnNames: ['customer_id'],
+        where: '"is_primary" IS TRUE',
+      }),
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        schema: 'customer_domain',
+        name: 'customer_phone_numbers',
+        columns: [
+          {
+            name: 'phone_id',
+            type: 'integer',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'customer_id',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'type',
+            type: 'varchar',
+            length: '20',
+            isNullable: false,
+          },
+          {
+            name: 'number',
+            type: 'varchar',
+            length: '20',
+            isNullable: false,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamptz',
+            isNullable: false,
+            default: () => 'now()',
+          },
+        ],
+        uniques: [
+          new TableUnique({
+            name: 'uq_customer_phone_numbers__customer_id_number',
+            columnNames: ['customer_id', 'number'],
+          }),
+        ],
+        foreignKeys: [
+          new TableForeignKey({
+            name: 'fk_customer_phone_numbers__customers__customer_id',
+            columnNames: ['customer_id'],
+            referencedSchema: 'customer_domain',
+            referencedTableName: 'customers',
+            referencedColumnNames: ['customer_id'],
+            onDelete: 'CASCADE',
+          }),
+        ],
+        indices: [
+          new TableIndex({
+            name: 'ix_customer_phone_numbers__customer_id',
+            columnNames: ['customer_id'],
+          }),
+        ],
+      }),
+      true,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex(
+      'customer_domain.customer_emails',
+      'idx_customer_email_primary',
+    );
+    await queryRunner.dropTable('customer_domain.customer_phone_numbers');
+    await queryRunner.dropTable('customer_domain.customer_emails');
+    await queryRunner.dropTable('customer_domain.customers');
+    await queryRunner.dropTable('customer_domain.privacy_settings');
+    await queryRunner.dropTable('customer_domain.postal_addresses');
+    await queryRunner.dropSchema('customer_domain', true);
+  }
+}

--- a/api/src/migrations/customer.md
+++ b/api/src/migrations/customer.md
@@ -1,0 +1,102 @@
+# Customer Migration
+
+## Source
+- Schema file: `ai/context/schemas/customer-entity-schema.json`
+- Schema commit: `087901fc5bde8d7794fe47a600c71c23b6fc2b60`
+- Database schema: `customer_domain`
+- Migration class: `20250928183335-customer.ts`
+
+## Table Overview
+
+### customer_domain.postal_addresses
+| Column | Type | Nullable | Default | Notes |
+| --- | --- | --- | --- | --- |
+| address_id | integer | NO | identity | Primary key |
+| line1 | varchar(255) | NO | — |  |
+| line2 | varchar(255) | YES | — | Optional second address line |
+| city | varchar(100) | NO | — |  |
+| state | varchar(100) | NO | — |  |
+| postal_code | varchar(20) | NO | — |  |
+| country | varchar(2) | NO | — | ISO-3166 alpha-2 code |
+
+### customer_domain.privacy_settings
+| Column | Type | Nullable | Default | Notes |
+| --- | --- | --- | --- | --- |
+| privacy_settings_id | integer | NO | identity | Primary key |
+| marketing_emails_enabled | boolean | NO | — |  |
+| two_factor_enabled | boolean | NO | — |  |
+
+### customer_domain.customers
+| Column | Type | Nullable | Default | Notes |
+| --- | --- | --- | --- | --- |
+| customer_id | uuid | NO | gen_random_uuid() | Primary key |
+| first_name | varchar(255) | NO | — |  |
+| middle_name | varchar(255) | YES | — | Optional |
+| last_name | varchar(255) | NO | — |  |
+| address_id | integer | YES | — | FK → postal_addresses.address_id |
+| privacy_settings_id | integer | YES | — | FK → privacy_settings.privacy_settings_id |
+| created_at | timestamptz | NO | now() |  |
+| updated_at | timestamptz | NO | now() |  |
+
+### customer_domain.customer_emails
+| Column | Type | Nullable | Default | Notes |
+| --- | --- | --- | --- | --- |
+| email_id | integer | NO | identity | Primary key |
+| customer_id | uuid | NO | — | FK → customers.customer_id |
+| email | varchar(320) | NO | — | format: email |
+| is_primary | boolean | NO | — | Partial index WHERE is_primary |
+| created_at | timestamptz | NO | now() |  |
+
+### customer_domain.customer_phone_numbers
+| Column | Type | Nullable | Default | Notes |
+| --- | --- | --- | --- | --- |
+| phone_id | integer | NO | identity | Primary key |
+| customer_id | uuid | NO | — | FK → customers.customer_id |
+| type | varchar(20) | NO | — | phone type label |
+| number | varchar(20) | NO | — | Unique per customer |
+| created_at | timestamptz | NO | now() |  |
+
+## Constraints & Indexes
+
+### Keys
+- `postal_addresses`: `pk_postal_addresses` (implicit) on `address_id`.
+- `privacy_settings`: `pk_privacy_settings` (implicit) on `privacy_settings_id`.
+- `customers`: `pk_customers` on `customer_id`.
+- `customer_emails`: `pk_customer_emails` on `email_id`.
+- `customer_phone_numbers`: `pk_customer_phone_numbers` on `phone_id`.
+
+### Foreign Keys
+- `fk_customers__postal_addresses__address_id`: `customers.address_id` → `postal_addresses.address_id` (ON DELETE SET NULL).
+- `fk_customers__privacy_settings__privacy_settings_id`: `customers.privacy_settings_id` → `privacy_settings.privacy_settings_id` (ON DELETE SET NULL).
+- `fk_customer_emails__customers__customer_id`: `customer_emails.customer_id` → `customers.customer_id` (ON DELETE CASCADE).
+- `fk_customer_phone_numbers__customers__customer_id`: `customer_phone_numbers.customer_id` → `customers.customer_id` (ON DELETE CASCADE).
+
+### Unique Constraints
+- `uq_customer_emails__customer_id_email`: ensures one email address per customer.
+- `uq_customer_phone_numbers__customer_id_number`: ensures one phone number per customer.
+
+### Indexes
+- `ix_customers__address_id` on `customers(address_id)`.
+- `ix_customers__privacy_settings_id` on `customers(privacy_settings_id)`.
+- `ix_customer_emails__customer_id` on `customer_emails(customer_id)`.
+- `idx_customer_email_primary` partial index on `customer_emails(customer_id) WHERE is_primary IS TRUE` for fast lookup of primary emails.
+- `ix_customer_phone_numbers__customer_id` on `customer_phone_numbers(customer_id)`.
+
+## Running the Migration
+1. `cd api`
+2. `npm install`
+3. Ensure `.env` is configured with database credentials and `DATABASE_SCHEMA=customer_domain` (or omit to use default).
+4. Run migrations: `npx typeorm migration:run -d src/database/data-source.ts`
+5. (Optional) Show status: `npx typeorm migration:show -d src/database/data-source.ts`
+
+## Reverting
+- `cd api`
+- `npx typeorm migration:revert -d src/database/data-source.ts`
+
+## Troubleshooting
+- `gen_random_uuid()` requires the PostgreSQL `pgcrypto` extension. Enable via `CREATE EXTENSION IF NOT EXISTS pgcrypto;`.
+- Partial index `idx_customer_email_primary` relies on the boolean column `is_primary`. Ensure TypeORM CLI uses PostgreSQL ≥ 11.
+- If the schema already exists with conflicting objects, either drop manually or set a different `DATABASE_SCHEMA` environment variable.
+
+## Change Log
+- 2025-09-28: Initial migration authored from `customer-entity-schema.json`.


### PR DESCRIPTION
## Summary
- add a customer-domain TypeORM migration generated from the JSON entity schema
- document the migration structure and runbook in `api/src/migrations/customer.md`
- scaffold customer-related entity classes with relations for addresses, emails, and phone numbers

## Testing
- npm --prefix api install
- npm --prefix api run lint *(fails: ESLint v9 requires migrating to eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d97eb9c5a0832d968eca1b922df3af