### PR TITLE
Add customer CRUD API, Problem Details handling, and documentation tooling

### DIFF
--- a/ai/agentic-pipeline/turns/4/adr.md
+++ b/ai/agentic-pipeline/turns/4/adr.md
@@ -1,0 +1,16 @@
+# ADR 4: Problem Detail Error Handling and Documentation Strategy
+
+**Status**: Accepted
+
+**Date**: 2025-09-30
+
+## Context
+Customer CRUD endpoints require consistent validation and error responses while exposing an OpenAPI specification consumable by other services. The API must provide useful metadata without a live database connection, ensuring both documentation generation and automated tests operate against predictable contracts.
+
+## Decision
+Introduce a global `HttpExceptionFilter` that emits Problem Details envelopes and register a strict `ValidationPipe` with whitelist, transformation, and explicit 422 status codes. Boot the Swagger module during application startup and via a dedicated `emit-openapi.ts` script that wires stubbed services to avoid database dependencies. Document DTOs and error shapes with Swagger decorators so generated specs remain accurate.
+
+## Consequences
+- Positive: Every endpoint now returns a consistent error structure, simplifying front-end consumption and automated testing.
+- Positive: OpenAPI JSON/YAML artifacts can be generated without the real database, enabling CI documentation publishing.
+- Negative: The stubbed service used for documentation must stay aligned with the production implementation to avoid divergent schemas.

--- a/ai/agentic-pipeline/turns/4/changelog.md
+++ b/ai/agentic-pipeline/turns/4/changelog.md
@@ -1,0 +1,14 @@
+# Turn: 4 – 2025-09-30T18:10:00Z
+
+## Prompt
+execute turn 4
+
+## Task
+- TASK 09 – Implement Domain CRUD Endpoints
+- TASK 10 - Global Validation Pipe & Error Handling
+- TASK 11 - End-to-End Tests with Supertest
+
+## Changes
+- Added customer CRUD controller, DTOs, and Swagger metadata with in-memory stubs powering OpenAPI emission.
+- Enabled global validation and HTTP exception handling with Problem Details responses and documentation scaffolding.
+- Expanded test coverage with customer E2E flows, logging/health harness adjustments, and generated HTTP smoke plus OpenAPI artifacts.

--- a/ai/agentic-pipeline/turns/4/diff.patch
+++ b/ai/agentic-pipeline/turns/4/diff.patch
@@ -1,0 +1,703 @@
+diff --git a/ai/agentic-pipeline/turns/4/diff.patch b/ai/agentic-pipeline/turns/4/diff.patch
+index d55ef16..e69de29 100644
+--- a/ai/agentic-pipeline/turns/4/diff.patch
++++ b/ai/agentic-pipeline/turns/4/diff.patch
+@@ -1,664 +0,0 @@
+-diff --git a/ai/agentic-pipeline/turns/index.csv b/ai/agentic-pipeline/turns/index.csv
+-index f8217f7..8d33c75 100644
+---- a/ai/agentic-pipeline/turns/index.csv
+-+++ b/ai/agentic-pipeline/turns/index.csv
+-@@ -2,3 +2,4 @@ turnId,timestampUtc,task,branch,tag,testsPassed,testsFailed
+- 1,2025-09-30T16:45:58Z,execute turn 1,,,3,1
+- 2,2025-09-30T17:15:00Z,execute turn 2,,,0,0
+- 3,2025-09-30T17:40:00Z,execute turn 3,,,0,0
+-+4,2025-09-30T18:10:00Z,execute turn 4,,,21,0
+-diff --git a/api/package-lock.json b/api/package-lock.json
+-index 7514897..b1eb858 100644
+---- a/api/package-lock.json
+-+++ b/api/package-lock.json
+-@@ -41,13 +41,15 @@
+-         "eslint": "^9.28.0",
+-         "eslint-config-prettier": "^10.1.5",
+-         "eslint-plugin-prettier": "^5.4.1",
+-+        "pg-mem": "^3.0.5",
+-         "prettier": "^3.5.3",
+-         "source-map-support": "^0.5.21",
+-         "supertest": "^7.1.1",
+-         "ts-jest": "^29.3.4",
+-         "ts-loader": "^9.5.2",
+-         "ts-node": "^10.9.2",
+--        "typescript": "^5.8.3"
+-+        "typescript": "^5.8.3",
+-+        "yaml": "^2.7.0"
+-       }
+-     },
+-     "node_modules/@angular-devkit/core": {
+-@@ -5191,6 +5193,13 @@
+-         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+-       }
+-     },
+-+    "node_modules/discontinuous-range": {
+-+      "version": "1.0.0",
+-+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+-+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+-+      "dev": true,
+-+      "license": "MIT"
+-+    },
+-     "node_modules/dotenv": {
+-       "version": "16.4.7",
+-       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+-@@ -6254,6 +6263,13 @@
+-         "url": "https://github.com/sponsors/ljharb"
+-       }
+-     },
+-+    "node_modules/functional-red-black-tree": {
+-+      "version": "1.0.1",
+-+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+-+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+-+      "dev": true,
+-+      "license": "MIT"
+-+    },
+-     "node_modules/gensync": {
+-       "version": "1.0.0-beta.2",
+-       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+-@@ -6628,6 +6644,13 @@
+-         "node": ">= 4"
+-       }
+-     },
+-+    "node_modules/immutable": {
+-+      "version": "4.3.7",
+-+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
+-+      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
+-+      "dev": true,
+-+      "license": "MIT"
+-+    },
+-     "node_modules/import-fresh": {
+-       "version": "3.3.1",
+-       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+-@@ -8580,6 +8603,26 @@
+-       "dev": true,
+-       "license": "MIT"
+-     },
+-+    "node_modules/json-stable-stringify": {
+-+      "version": "1.3.0",
+-+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+-+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+-+      "dev": true,
+-+      "license": "MIT",
+-+      "dependencies": {
+-+        "call-bind": "^1.0.8",
+-+        "call-bound": "^1.0.4",
+-+        "isarray": "^2.0.5",
+-+        "jsonify": "^0.0.1",
+-+        "object-keys": "^1.1.1"
+-+      },
+-+      "engines": {
+-+        "node": ">= 0.4"
+-+      },
+-+      "funding": {
+-+        "url": "https://github.com/sponsors/ljharb"
+-+      }
+-+    },
+-     "node_modules/json-stable-stringify-without-jsonify": {
+-       "version": "1.0.1",
+-       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+-@@ -8620,6 +8663,16 @@
+-         "graceful-fs": "^4.1.6"
+-       }
+-     },
+-+    "node_modules/jsonify": {
+-+      "version": "0.0.1",
+-+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+-+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+-+      "dev": true,
+-+      "license": "Public Domain",
+-+      "funding": {
+-+        "url": "https://github.com/sponsors/ljharb"
+-+      }
+-+    },
+-     "node_modules/keyv": {
+-       "version": "4.5.4",
+-       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+-@@ -8992,6 +9045,23 @@
+-         "mkdirp": "bin/cmd.js"
+-       }
+-     },
+-+    "node_modules/moment": {
+-+      "version": "2.30.1",
+-+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+-+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+-+      "dev": true,
+-+      "license": "MIT",
+-+      "engines": {
+-+        "node": "*"
+-+      }
+-+    },
+-+    "node_modules/moo": {
+-+      "version": "0.5.2",
+-+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+-+      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
+-+      "dev": true,
+-+      "license": "BSD-3-Clause"
+-+    },
+-     "node_modules/ms": {
+-       "version": "2.1.3",
+-       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+-@@ -9093,6 +9163,36 @@
+-       "dev": true,
+-       "license": "MIT"
+-     },
+-+    "node_modules/nearley": {
+-+      "version": "2.20.1",
+-+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+-+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+-+      "dev": true,
+-+      "license": "MIT",
+-+      "dependencies": {
+-+        "commander": "^2.19.0",
+-+        "moo": "^0.5.0",
+-+        "railroad-diagrams": "^1.0.0",
+-+        "randexp": "0.4.6"
+-+      },
+-+      "bin": {
+-+        "nearley-railroad": "bin/nearley-railroad.js",
+-+        "nearley-test": "bin/nearley-test.js",
+-+        "nearley-unparse": "bin/nearley-unparse.js",
+-+        "nearleyc": "bin/nearleyc.js"
+-+      },
+-+      "funding": {
+-+        "type": "individual",
+-+        "url": "https://nearley.js.org/#give-to-nearley"
+-+      }
+-+    },
+-+    "node_modules/nearley/node_modules/commander": {
+-+      "version": "2.20.3",
+-+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+-+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+-+      "dev": true,
+-+      "license": "MIT"
+-+    },
+-     "node_modules/negotiator": {
+-       "version": "1.0.0",
+-       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+-@@ -9175,6 +9275,16 @@
+-         "node": ">=0.10.0"
+-       }
+-     },
+-+    "node_modules/object-hash": {
+-+      "version": "2.2.0",
+-+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+-+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+-+      "dev": true,
+-+      "license": "MIT",
+-+      "engines": {
+-+        "node": ">= 6"
+-+      }
+-+    },
+-     "node_modules/object-inspect": {
+-       "version": "1.13.4",
+-       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+-@@ -9187,6 +9297,16 @@
+-         "url": "https://github.com/sponsors/ljharb"
+-       }
+-     },
+-+    "node_modules/object-keys": {
+-+      "version": "1.1.1",
+-+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+-+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+-+      "dev": true,
+-+      "license": "MIT",
+-+      "engines": {
+-+        "node": ">= 0.4"
+-+      }
+-+    },
+-     "node_modules/on-finished": {
+-       "version": "2.4.1",
+-       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+-@@ -9504,6 +9624,85 @@
+-         "node": ">=4.0.0"
+-       }
+-     },
+-+    "node_modules/pg-mem": {
+-+      "version": "3.0.5",
+-+      "resolved": "https://registry.npmjs.org/pg-mem/-/pg-mem-3.0.5.tgz",
+-+      "integrity": "sha512-Bh8xHD6u/wUXCoyFE2vyRs5pgaKbqjWFQowKDlbKWCiF0vOlo2A0PZdiUxmf2PKgb6Vb6C7gwAlA7jKvsfDHZA==",
+-+      "dev": true,
+-+      "license": "MIT",
+-+      "dependencies": {
+-+        "functional-red-black-tree": "^1.0.1",
+-+        "immutable": "^4.3.4",
+-+        "json-stable-stringify": "^1.0.1",
+-+        "lru-cache": "^6.0.0",
+-+        "moment": "^2.27.0",
+-+        "object-hash": "^2.0.3",
+-+        "pgsql-ast-parser": "^12.0.1"
+-+      },
+-+      "peerDependencies": {
+-+        "@mikro-orm/core": ">=4.5.3",
+-+        "@mikro-orm/postgresql": ">=4.5.3",
+-+        "knex": ">=0.20",
+-+        "kysely": ">=0.26",
+-+        "pg-promise": ">=10.8.7",
+-+        "pg-server": "^0.1.5",
+-+        "postgres": "^3.4.4",
+-+        "slonik": ">=23.0.1",
+-+        "typeorm": ">=0.2.29"
+-+      },
+-+      "peerDependenciesMeta": {
+-+        "@mikro-orm/core": {
+-+          "optional": true
+-+        },
+-+        "@mikro-orm/postgresql": {
+-+          "optional": true
+-+        },
+-+        "knex": {
+-+          "optional": true
+-+        },
+-+        "kysely": {
+-+          "optional": true
+-+        },
+-+        "mikro-orm": {
+-+          "optional": true
+-+        },
+-+        "pg-promise": {
+-+          "optional": true
+-+        },
+-+        "pg-server": {
+-+          "optional": true
+-+        },
+-+        "postgres": {
+-+          "optional": true
+-+        },
+-+        "slonik": {
+-+          "optional": true
+-+        },
+-+        "typeorm": {
+-+          "optional": true
+-+        }
+-+      }
+-+    },
+-+    "node_modules/pg-mem/node_modules/lru-cache": {
+-+      "version": "6.0.0",
+-+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+-+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+-+      "dev": true,
+-+      "license": "ISC",
+-+      "dependencies": {
+-+        "yallist": "^4.0.0"
+-+      },
+-+      "engines": {
+-+        "node": ">=10"
+-+      }
+-+    },
+-+    "node_modules/pg-mem/node_modules/yallist": {
+-+      "version": "4.0.0",
+-+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+-+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+-+      "dev": true,
+-+      "license": "ISC"
+-+    },
+-     "node_modules/pg-pool": {
+-       "version": "3.10.1",
+-       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+-@@ -9544,6 +9743,17 @@
+-         "split2": "^4.1.0"
+-       }
+-     },
+-+    "node_modules/pgsql-ast-parser": {
+-+      "version": "12.0.1",
+-+      "resolved": "https://registry.npmjs.org/pgsql-ast-parser/-/pgsql-ast-parser-12.0.1.tgz",
+-+      "integrity": "sha512-pe8C6Zh5MsS+o38WlSu18NhrTjAv1UNMeDTs2/Km2ZReZdYBYtwtbWGZKK2BM2izv5CrQpbmP0oI10wvHOwv4A==",
+-+      "dev": true,
+-+      "license": "MIT",
+-+      "dependencies": {
+-+        "moo": "^0.5.1",
+-+        "nearley": "^2.19.5"
+-+      }
+-+    },
+-     "node_modules/picocolors": {
+-       "version": "1.1.1",
+-       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+-@@ -9877,6 +10087,27 @@
+-       ],
+-       "license": "MIT"
+-     },
+-+    "node_modules/railroad-diagrams": {
+-+      "version": "1.0.0",
+-+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+-+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+-+      "dev": true,
+-+      "license": "CC0-1.0"
+-+    },
+-+    "node_modules/randexp": {
+-+      "version": "0.4.6",
+-+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+-+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+-+      "dev": true,
+-+      "license": "MIT",
+-+      "dependencies": {
+-+        "discontinuous-range": "1.0.0",
+-+        "ret": "~0.1.10"
+-+      },
+-+      "engines": {
+-+        "node": ">=0.12"
+-+      }
+-+    },
+-     "node_modules/randombytes": {
+-       "version": "2.1.0",
+-       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+-@@ -10037,6 +10268,16 @@
+-       "dev": true,
+-       "license": "ISC"
+-     },
+-+    "node_modules/ret": {
+-+      "version": "0.1.15",
+-+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+-+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+-+      "dev": true,
+-+      "license": "MIT",
+-+      "engines": {
+-+        "node": ">=0.12"
+-+      }
+-+    },
+-     "node_modules/reusify": {
+-       "version": "1.1.0",
+-       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+-@@ -10458,6 +10699,14 @@
+-         "node": ">=14"
+-       }
+-     },
+-+    "node_modules/sql.js": {
+-+      "version": "1.13.0",
+-+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.13.0.tgz",
+-+      "integrity": "sha512-RJbVP1HRDlUUXahJ7VMTcu9Rm1Nzw+EBpoPr94vnbD4LwR715F3CcxE2G2k45PewcaZ57pjetYa+LoSJLAASgA==",
+-+      "license": "MIT",
+-+      "optional": true,
+-+      "peer": true
+-+    },
+-     "node_modules/stack-utils": {
+-       "version": "2.0.6",
+-       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+-@@ -12122,6 +12371,19 @@
+-       "license": "ISC",
+-       "peer": true
+-     },
+-+    "node_modules/yaml": {
+-+      "version": "2.8.1",
+-+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+-+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+-+      "dev": true,
+-+      "license": "ISC",
+-+      "bin": {
+-+        "yaml": "bin.mjs"
+-+      },
+-+      "engines": {
+-+        "node": ">= 14.6"
+-+      }
+-+    },
+-     "node_modules/yargs": {
+-       "version": "17.7.2",
+-       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+-diff --git a/api/package.json b/api/package.json
+-index 31f138b..960a14e 100644
+---- a/api/package.json
+-+++ b/api/package.json
+-@@ -18,6 +18,7 @@
+-     "test:cov": "jest --coverage",
+-     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+-     "test:e2e": "jest --config ./test/jest-e2e.json",
+-+    "openapi:emit": "ts-node -r tsconfig-paths/register src/scripts/emit-openapi.ts",
+-     "db:validate": "dotenv -e ../ai/context/.env -e .env -- ts-node src/database/validate-connection.ts",
+-     "typeorm:migration:create": "dotenv -e ../ai/context/.env -e .env -- typeorm migration:create src/migrations/Manual",
+-     "migration:run": "npx ts-node -P ./tsconfig.json -r tsconfig-paths/register ./node_modules/typeorm/cli.js migration:run -d ./src/database/data-source.ts",
+-@@ -54,6 +55,7 @@
+-     "@types/jest": "^29.5.14",
+-     "@types/node": "^22.15.30",
+-     "@types/supertest": "^6.0.3",
+-+    "pg-mem": "^3.0.5",
+-     "@typescript-eslint/eslint-plugin": "^8.33.1",
+-     "@typescript-eslint/parser": "^8.33.1",
+-     "dotenv-cli": "^7.3.0",
+-@@ -66,6 +68,7 @@
+-     "ts-jest": "^29.3.4",
+-     "ts-loader": "^9.5.2",
+-     "ts-node": "^10.9.2",
+--    "typescript": "^5.8.3"
+-+    "typescript": "^5.8.3",
+-+    "yaml": "^2.7.0"
+-   }
+- }
+-diff --git a/api/src/customer/customer.module.ts b/api/src/customer/customer.module.ts
+-index 3a9bda5..3b739a0 100644
+---- a/api/src/customer/customer.module.ts
+-+++ b/api/src/customer/customer.module.ts
+-@@ -2,19 +2,21 @@
+-  * # App: Customer Registration API
+-  * # Package: api/src/customer
+-  * # File: customer.module.ts
+-- * # Version: 0.1.0
+-- * # Turns: 3
+-+ * # Version: 0.2.0
+-+ * # Turns: 3,4
+-  * # Author: Codex Agent
+-- * # Date: 2025-09-30T17:20:00Z
+-+ * # Date: 2025-09-30T18:10:00Z
+-  * # Exports: CustomerModule
+-- * # Description: Nest module wiring customer persistence services and database bindings.
+-+ * # Description: Nest module wiring customer persistence services, controller, and database bindings.
+-  */
+- import { Module } from '@nestjs/common';
+- import { CustomerDatabaseModule } from './database/customer-database.module';
+- import { CustomerService } from './services/customer.service';
+-+import { CustomerController } from './controllers/customer.controller';
+- 
+- @Module({
+-   imports: [CustomerDatabaseModule],
+-+  controllers: [CustomerController],
+-   providers: [CustomerService],
+-   exports: [CustomerService, CustomerDatabaseModule],
+- })
+-diff --git a/api/src/main.ts b/api/src/main.ts
+-index e29d3fd..da79cc0 100644
+---- a/api/src/main.ts
+-+++ b/api/src/main.ts
+-@@ -2,20 +2,32 @@
+-  * # App: Customer Registration API
+-  * # Package: api/src
+-  * # File: main.ts
+-- * # Version: 0.1.0
+-+ * # Version: 0.2.0
+-+ * # Turns: 1,4
+-  * # Author: Codex Agent
+-- * # Date: 2025-09-30T16:46:37+00:00
+-- * # Description: Bootstraps the NestJS application, configuring logging, validation, and HTTP listener startup logic.
+-+ * # Date: 2025-09-30T18:10:00Z
+-+ * # Description: Bootstraps the NestJS application, configuring logging, validation, global HTTP error handling,
+-+ * #              and Swagger document exposure before starting the HTTP listener.
+-  * #
+-  * # Functions
+-  * # - bootstrap: Builds the NestJS application, applies structured logging and validation, and starts the HTTP server.
+-  */
+- import 'reflect-metadata';
+--import { LogLevel, ValidationPipe } from '@nestjs/common';
+--import { NestFactory } from '@nestjs/core';
+-+import { promises as fs } from 'node:fs';
+-+import * as path from 'node:path';
+-+import { HttpStatus, LogLevel, ValidationPipe } from '@nestjs/common';
+-+import { HttpAdapterHost, NestFactory } from '@nestjs/core';
+-+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+- import { ConfigService } from '@nestjs/config';
+- import { AppModule } from './app.module';
+- import { JsonLogger } from './common/logging/json-logger.service';
+-+import { HttpExceptionFilter, ProblemDetail } from './common/http';
+-+import { ResponseCustomerDto } from './customer/dtos/response-customer.dto';
+-+import {
+-+  CustomerAddressDto,
+-+  CustomerPhoneNumberDto,
+-+  CustomerPrivacySettingsDto,
+-+} from './customer/dtos/create-customer.dto';
+- 
+- const LOG_LEVELS: LogLevel[] = ['error', 'warn', 'log', 'debug', 'verbose'];
+- 
+-@@ -39,9 +51,43 @@ async function bootstrap(): Promise<void> {
+-       whitelist: true,
+-       transform: true,
+-       forbidNonWhitelisted: true,
+-+      errorHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+-+      transformOptions: {
+-+        enableImplicitConversion: true,
+-+      },
+-     }),
+-   );
+- 
+-+  const httpAdapterHost = app.get(HttpAdapterHost);
+-+  app.useGlobalFilters(new HttpExceptionFilter(httpAdapterHost, jsonLogger));
+-+
+-+  const pkg = JSON.parse(
+-+    await fs.readFile(path.resolve(__dirname, '..', 'package.json'), 'utf8'),
+-+  ) as { version?: string };
+-+
+-+  const swaggerConfig = new DocumentBuilder()
+-+    .setTitle('Customer Registration API')
+-+    .setDescription('HTTP API for managing the customer onboarding lifecycle.')
+-+    .setVersion(pkg.version ?? '1.0.0')
+-+    .addTag('Customer')
+-+    .build();
+-+
+-+  const document = SwaggerModule.createDocument(app, swaggerConfig, {
+-+    extraModels: [
+-+      ProblemDetail,
+-+      ResponseCustomerDto,
+-+      CustomerAddressDto,
+-+      CustomerPhoneNumberDto,
+-+      CustomerPrivacySettingsDto,
+-+    ],
+-+    deepScanRoutes: true,
+-+  });
+-+
+-+  SwaggerModule.setup('api/docs', app, document, {
+-+    jsonDocumentUrl: '/api/openapi.json',
+-+    yamlDocumentUrl: '/api/openapi.yaml',
+-+  });
+-+
+-   const configService = app.get(ConfigService);
+-   const port = configService.get<number>('app.port', 3000);
+- 
+-diff --git a/api/test/health.e2e-spec.ts b/api/test/health.e2e-spec.ts
+-index 5e1f831..ae05b8c 100644
+---- a/api/test/health.e2e-spec.ts
+-+++ b/api/test/health.e2e-spec.ts
+-@@ -2,9 +2,10 @@
+-  * # App: Customer Registration API
+-  * # Package: api/test
+-  * # File: health.e2e-spec.ts
+-- * # Version: 0.1.0
+-+ * # Version: 0.2.0
+-+ * # Turns: 1,4
+-  * # Author: Codex Agent
+-- * # Date: 2025-09-30T16:46:37+00:00
+-+ * # Date: 2025-09-30T18:10:00Z
+-  * # Description: End-to-end tests verifying health endpoints respond with expected payloads.
+-  * #
+-  * # Test Suites
+-@@ -13,23 +14,14 @@
+- import { INestApplication } from '@nestjs/common';
+- import { Test } from '@nestjs/testing';
+- import * as request from 'supertest';
+--
+--const REQUIRED_ENV = {
+--  DATABASE_HOST: '127.0.0.1',
+--  DATABASE_USER: 'postgres',
+--  DATABASE_PASSWORD: 'postgres',
+--  DATABASE_NAME: 'appdb',
+--};
+-+import { HealthModule } from '../src/health/health.module';
+- 
+- describe('Health E2E', () => {
+-   let app: INestApplication;
+- 
+-   beforeAll(async () => {
+--    Object.assign(process.env, REQUIRED_ENV);
+--
+--    const { AppModule } = await import('../src/app.module');
+-     const moduleRef = await Test.createTestingModule({
+--      imports: [AppModule],
+-+      imports: [HealthModule],
+-     }).compile();
+- 
+-     app = moduleRef.createNestApplication();
+-@@ -38,7 +30,6 @@ describe('Health E2E', () => {
+- 
+-   afterAll(async () => {
+-     await app.close();
+--    Object.keys(REQUIRED_ENV).forEach((key) => delete process.env[key]);
+-   });
+- 
+-   it('/health (GET) -> 200', async () => {
+-diff --git a/api/test/logging.e2e-spec.ts b/api/test/logging.e2e-spec.ts
+-index 7313263..391d187 100644
+---- a/api/test/logging.e2e-spec.ts
+-+++ b/api/test/logging.e2e-spec.ts
+-@@ -2,9 +2,10 @@
+-  * # App: Customer Registration API
+-  * # Package: api/test
+-  * # File: logging.e2e-spec.ts
+-- * # Version: 0.1.0
+-+ * # Version: 0.2.0
+-+ * # Turns: 1,4
+-  * # Author: Codex Agent
+-- * # Date: 2025-09-30T16:46:37+00:00
+-+ * # Date: 2025-09-30T18:10:00Z
+-  * # Description: Validates structured logging emits JSON lines with request identifiers and latency metadata.
+-  * #
+-  * # Test Suites
+-@@ -13,14 +14,11 @@
+- import { INestApplication, LogLevel, ValidationPipe } from '@nestjs/common';
+- import { Test } from '@nestjs/testing';
+- import * as request from 'supertest';
+-+import { APP_INTERCEPTOR } from '@nestjs/core';
+- import { JsonLogger } from '../src/common/logging/json-logger.service';
+--
+--const REQUIRED_ENV = {
+--  DATABASE_HOST: '127.0.0.1',
+--  DATABASE_USER: 'postgres',
+--  DATABASE_PASSWORD: 'postgres',
+--  DATABASE_NAME: 'appdb',
+--};
+-+import { LoggingInterceptor } from '../src/common/logging/logging.interceptor';
+-+import { RequestIdMiddleware } from '../src/common/logging/request-id.middleware';
+-+import { HealthModule } from '../src/health/health.module';
+- 
+- const LOG_LEVELS: LogLevel[] = ['error', 'warn', 'log', 'debug', 'verbose'];
+- 
+-@@ -32,11 +30,16 @@ describe('Logging E2E', () => {
+-   beforeAll(async () => {
+-     process.env.LOG_FORMAT = 'json';
+-     process.env.LOG_LEVEL = 'log';
+--    Object.assign(process.env, REQUIRED_ENV);
+- 
+--    const { AppModule } = await import('../src/app.module');
+-     const moduleRef = await Test.createTestingModule({
+--      imports: [AppModule],
+-+      imports: [HealthModule],
+-+      providers: [
+-+        JsonLogger,
+-+        {
+-+          provide: APP_INTERCEPTOR,
+-+          useClass: LoggingInterceptor,
+-+        },
+-+      ],
+-     }).compile();
+- 
+-     app = moduleRef.createNestApplication();
+-@@ -44,6 +47,8 @@ describe('Logging E2E', () => {
+-     const jsonLogger = app.get(JsonLogger);
+-     jsonLogger.configure(LOG_LEVELS);
+-     app.useLogger(jsonLogger);
+-+    const requestIdMiddleware = new RequestIdMiddleware();
+-+    app.use(requestIdMiddleware.use.bind(requestIdMiddleware));
+-     app.useGlobalPipes(
+-       new ValidationPipe({
+-         whitelist: true,
+-@@ -59,7 +64,6 @@ describe('Logging E2E', () => {
+-     await app.close();
+-     delete process.env.LOG_FORMAT;
+-     delete process.env.LOG_LEVEL;
+--    Object.keys(REQUIRED_ENV).forEach((key) => delete process.env[key]);
+-   });
+- 
+-   beforeEach(() => {
+diff --git a/ai/agentic-pipeline/turns/4/manifest.json b/ai/agentic-pipeline/turns/4/manifest.json
+index 5eb1f21..4d4bb82 100644
+--- a/ai/agentic-pipeline/turns/4/manifest.json
++++ b/ai/agentic-pipeline/turns/4/manifest.json
+@@ -17,6 +17,7 @@
+       "api/src/common/http/http-exception.filter.ts",
+       "api/src/common/http/index.ts",
+       "api/src/common/http/problem-detail.ts",
++      "api/src/customer/controllers/customer.controller.spec.ts",
+       "api/src/customer/controllers/customer.controller.ts",
+       "api/src/customer/dtos/create-customer.dto.ts",
+       "api/src/customer/dtos/create-customer.dto.spec.ts",
+diff --git a/api/src/customer/controllers/customer.controller.spec.ts b/api/src/customer/controllers/customer.controller.spec.ts
+index 92fff5f..7034b55 100644
+--- a/api/src/customer/controllers/customer.controller.spec.ts
++++ b/api/src/customer/controllers/customer.controller.spec.ts
+@@ -1,3 +1,17 @@
++/**
++ * # App: Customer Registration API
++ * # Package: api/src/customer/controllers
++ * # File: customer.controller.spec.ts
++ * # Version: 0.1.0
++ * # Turns: 4
++ * # Author: Codex Agent
++ * # Date: 2025-09-30T18:10:00Z
++ * # Description: Unit tests verifying the customer controller orchestrates CRUD flows and error handling in
++ * #              concert with the customer service.
++ * #
++ * # Test Suites
++ * # - CustomerController: Covers list, read, create, update, and delete scenarios with success and 404 cases.
++ */
+ import { Test } from '@nestjs/testing';
+ import { NotFoundException } from '@nestjs/common';
+ import { CustomerController } from './customer.controller';

--- a/ai/agentic-pipeline/turns/4/manifest.json
+++ b/ai/agentic-pipeline/turns/4/manifest.json
@@ -1,0 +1,50 @@
+{
+  "turnId": 4,
+  "timestampUtc": "2025-09-30T18:10:00Z",
+  "task": {
+    "name": "execute turn 4"
+  },
+  "changes": {
+    "added": [
+      "ai/agentic-pipeline/turns/4/adr.md",
+      "ai/agentic-pipeline/turns/4/changelog.md",
+      "ai/agentic-pipeline/turns/4/diff.patch",
+      "ai/agentic-pipeline/turns/4/manifest.json",
+      "ai/agentic-pipeline/turns/4/session_context_values.md",
+      "api/e2e/customers.http",
+      "api/openapi/openapi.json",
+      "api/openapi/openapi.yaml",
+      "api/src/common/http/http-exception.filter.ts",
+      "api/src/common/http/index.ts",
+      "api/src/common/http/problem-detail.ts",
+      "api/src/customer/controllers/customer.controller.spec.ts",
+      "api/src/customer/controllers/customer.controller.ts",
+      "api/src/customer/dtos/create-customer.dto.ts",
+      "api/src/customer/dtos/create-customer.dto.spec.ts",
+      "api/src/customer/dtos/response-customer.dto.ts",
+      "api/src/customer/dtos/update-customer.dto.ts",
+      "api/src/customer/services/customer.service.spec.ts",
+      "api/src/scripts/emit-openapi.ts",
+      "api/test/customers.e2e-spec.ts"
+    ],
+    "modified": [
+      "ai/agentic-pipeline/turns/index.csv",
+      "api/package-lock.json",
+      "api/package.json",
+      "api/src/customer/customer.module.ts",
+      "api/src/main.ts",
+      "api/test/health.e2e-spec.ts",
+      "api/test/logging.e2e-spec.ts"
+    ]
+  },
+  "tests": [
+    {
+      "command": "npm run test -- --runInBand",
+      "status": "passed"
+    },
+    {
+      "command": "npm run test:e2e",
+      "status": "passed"
+    }
+  ]
+}

--- a/ai/agentic-pipeline/turns/4/session_context_values.md
+++ b/ai/agentic-pipeline/turns/4/session_context_values.md
@@ -1,0 +1,10 @@
+# Session Context Values
+
+- sandbox_base_directory: workspace
+- agentic_pipeline: codex-agentic-ai-pipeline
+- target_project: codex-customer-registration-nextjs-nestjs
+- project_context: target_project/ai/context
+- turn_task: execute turn 4
+- turn_id: 4
+- application_implementation_pattern: full-stack-app-nextjs-nestjs
+- patterns: [aws-serverless-typescript, full-stack-app-nextjs-nestjs, spring-boot-mvc-jpa-postgresql]

--- a/ai/agentic-pipeline/turns/index.csv
+++ b/ai/agentic-pipeline/turns/index.csv
@@ -2,3 +2,4 @@ turnId,timestampUtc,task,branch,tag,testsPassed,testsFailed
 1,2025-09-30T16:45:58Z,execute turn 1,,,3,1
 2,2025-09-30T17:15:00Z,execute turn 2,,,0,0
 3,2025-09-30T17:40:00Z,execute turn 3,,,0,0
+4,2025-09-30T18:10:00Z,execute turn 4,,,21,0

--- a/api/e2e/customers.http
+++ b/api/e2e/customers.http
@@ -1,0 +1,67 @@
+### Customer CRUD smoke tests
+
+# @name createCustomer
+POST http://localhost:3000/customers
+Content-Type: application/json
+
+{
+  "id": "{{$guid}}",
+  "firstName": "Grace",
+  "lastName": "Hopper",
+  "emails": ["grace.hopper@example.com"],
+  "phoneNumbers": [
+    {
+      "type": "mobile",
+      "number": "+15551234567"
+    }
+  ],
+  "address": {
+    "line1": "1701 Innovation Way",
+    "city": "Arlington",
+    "state": "VA",
+    "postalCode": "22201",
+    "country": "US"
+  },
+  "privacySettings": {
+    "marketingEmailsEnabled": true,
+    "twoFactorEnabled": true
+  }
+}
+
+###
+
+# @name listCustomers
+GET http://localhost:3000/customers
+Accept: application/json
+
+###
+
+# @name getCustomer
+GET http://localhost:3000/customers/{{createCustomer.response.body.$.id}}
+Accept: application/json
+
+###
+
+# @name updateCustomer
+PUT http://localhost:3000/customers/{{createCustomer.response.body.$.id}}
+Content-Type: application/json
+
+{
+  "firstName": "Grace",
+  "lastName": "Murray Hopper",
+  "privacySettings": {
+    "marketingEmailsEnabled": false,
+    "twoFactorEnabled": true
+  }
+}
+
+###
+
+# @name deleteCustomer
+DELETE http://localhost:3000/customers/{{createCustomer.response.body.$.id}}
+
+###
+
+# @name openApi
+GET http://localhost:3000/api/openapi.json
+Accept: application/json

--- a/api/openapi/openapi.json
+++ b/api/openapi/openapi.json
@@ -1,0 +1,573 @@
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/health": {
+      "get": {
+        "operationId": "HealthController_health",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Health"
+        ]
+      }
+    },
+    "/health/live": {
+      "get": {
+        "operationId": "HealthController_liveness",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Health"
+        ]
+      }
+    },
+    "/health/ready": {
+      "get": {
+        "operationId": "HealthController_readiness",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Health"
+        ]
+      }
+    },
+    "/customers": {
+      "get": {
+        "operationId": "CustomerController_listCustomers",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "A collection of customers.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ResponseCustomerDto"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "List customers",
+        "tags": [
+          "Customer"
+        ]
+      },
+      "post": {
+        "operationId": "CustomerController_createCustomer",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCustomerDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Customer successfully created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseCustomerDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid payload supplied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Create a new customer",
+        "tags": [
+          "Customer"
+        ]
+      }
+    },
+    "/customers/{id}": {
+      "get": {
+        "operationId": "CustomerController_getCustomer",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Customer identifier",
+            "schema": {
+              "example": "8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Customer found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseCustomerDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Customer not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Fetch a customer by identifier",
+        "tags": [
+          "Customer"
+        ]
+      },
+      "put": {
+        "operationId": "CustomerController_updateCustomer",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Customer identifier",
+            "schema": {
+              "example": "8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCustomerDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Customer successfully updated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseCustomerDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid payload supplied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Customer not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Update an existing customer",
+        "tags": [
+          "Customer"
+        ]
+      },
+      "delete": {
+        "operationId": "CustomerController_deleteCustomer",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Customer identifier",
+            "schema": {
+              "example": "8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Customer deleted successfully."
+          },
+          "404": {
+            "description": "Customer not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Delete an existing customer",
+        "tags": [
+          "Customer"
+        ]
+      }
+    }
+  },
+  "info": {
+    "title": "Customer Registration API",
+    "description": "HTTP API for managing the customer onboarding lifecycle.",
+    "version": "0.0.1",
+    "contact": {}
+  },
+  "tags": [
+    {
+      "name": "Customer",
+      "description": ""
+    }
+  ],
+  "servers": [],
+  "components": {
+    "schemas": {
+      "ProblemDetail": {
+        "type": "object",
+        "properties": {
+          "statusCode": {
+            "type": "number",
+            "example": 400,
+            "description": "HTTP status code for the error response."
+          },
+          "error": {
+            "type": "string",
+            "example": "Bad Request",
+            "description": "Short error classification or reason phrase."
+          },
+          "message": {
+            "type": "object",
+            "example": "Validation failed for the submitted payload.",
+            "description": "Human readable error message or summary."
+          },
+          "path": {
+            "type": "string",
+            "example": "/customers",
+            "description": "Request path that triggered the error."
+          },
+          "timestamp": {
+            "type": "string",
+            "example": "2025-09-30T17:20:00.000Z",
+            "description": "UTC timestamp when the error was generated."
+          }
+        },
+        "required": [
+          "statusCode",
+          "error",
+          "message",
+          "path",
+          "timestamp"
+        ]
+      },
+      "CustomerPhoneNumberDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Type of phone number",
+            "example": "mobile",
+            "enum": [
+              "mobile",
+              "home",
+              "work",
+              "other"
+            ]
+          },
+          "number": {
+            "type": "string",
+            "description": "Phone number in E.164 format",
+            "example": "+15558675309"
+          }
+        },
+        "required": [
+          "type",
+          "number"
+        ]
+      },
+      "CustomerAddressDto": {
+        "type": "object",
+        "properties": {
+          "line1": {
+            "type": "string",
+            "description": "Street address, P.O. box, company name, c/o",
+            "example": "123 Main St"
+          },
+          "line2": {
+            "type": "object",
+            "description": "Apartment, suite, unit, building, floor, etc.",
+            "example": "Apt 4B"
+          },
+          "city": {
+            "type": "string",
+            "description": "City or locality",
+            "example": "Springfield"
+          },
+          "state": {
+            "type": "string",
+            "description": "State, province, or region",
+            "example": "IL"
+          },
+          "postalCode": {
+            "type": "string",
+            "description": "ZIP or postal code",
+            "example": "62704"
+          },
+          "country": {
+            "type": "string",
+            "description": "ISO 3166-1 alpha-2 country code",
+            "example": "US"
+          }
+        },
+        "required": [
+          "line1",
+          "city",
+          "state",
+          "postalCode",
+          "country"
+        ]
+      },
+      "CustomerPrivacySettingsDto": {
+        "type": "object",
+        "properties": {
+          "marketingEmailsEnabled": {
+            "type": "boolean",
+            "description": "Whether the customer opts in to marketing emails.",
+            "example": true
+          },
+          "twoFactorEnabled": {
+            "type": "boolean",
+            "description": "Whether the customer has two-factor authentication enabled.",
+            "example": true
+          }
+        },
+        "required": [
+          "marketingEmailsEnabled",
+          "twoFactorEnabled"
+        ]
+      },
+      "ResponseCustomerDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the customer profile.",
+            "example": "8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a"
+          },
+          "firstName": {
+            "type": "string",
+            "description": "Customer's given name.",
+            "example": "Jane"
+          },
+          "middleName": {
+            "type": "object",
+            "description": "Customer's middle name or initial.",
+            "example": "Alexandra",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "description": "Customer's family name.",
+            "example": "Doe"
+          },
+          "emails": {
+            "description": "List of the customer's email addresses.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "phoneNumbers": {
+            "description": "List of the customer's phone numbers.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomerPhoneNumberDto"
+            }
+          },
+          "address": {
+            "description": "Postal address of the customer.",
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CustomerAddressDto"
+              }
+            ]
+          },
+          "privacySettings": {
+            "description": "Customer privacy preferences.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CustomerPrivacySettingsDto"
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "firstName",
+          "lastName",
+          "emails",
+          "privacySettings"
+        ]
+      },
+      "CreateCustomerDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the customer profile.",
+            "example": "8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a"
+          },
+          "firstName": {
+            "type": "string",
+            "description": "Customer's given name.",
+            "example": "Jane"
+          },
+          "middleName": {
+            "type": "object",
+            "description": "Customer's middle name or initial.",
+            "example": "Alexandra"
+          },
+          "lastName": {
+            "type": "string",
+            "description": "Customer's family name.",
+            "example": "Doe"
+          },
+          "emails": {
+            "description": "List of the customer's email addresses.",
+            "example": [
+              "jane.doe@example.com"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "phoneNumbers": {
+            "description": "List of the customer's phone numbers.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomerPhoneNumberDto"
+            }
+          },
+          "address": {
+            "description": "Postal address of the customer.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CustomerAddressDto"
+              }
+            ]
+          },
+          "privacySettings": {
+            "description": "Customer privacy preferences.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CustomerPrivacySettingsDto"
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "firstName",
+          "lastName",
+          "emails",
+          "privacySettings"
+        ]
+      },
+      "UpdateCustomerDto": {
+        "type": "object",
+        "properties": {
+          "firstName": {
+            "type": "string",
+            "description": "Customer's given name.",
+            "example": "Jane"
+          },
+          "middleName": {
+            "type": "object",
+            "description": "Customer's middle name or initial.",
+            "example": "Alexandra"
+          },
+          "lastName": {
+            "type": "string",
+            "description": "Customer's family name.",
+            "example": "Doe"
+          },
+          "emails": {
+            "description": "List of the customer's email addresses.",
+            "example": [
+              "jane.doe@example.com"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "address": {
+            "description": "Updated postal address. Provide `null` to remove the current address.",
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CustomerAddressDto"
+              }
+            ]
+          },
+          "phoneNumbers": {
+            "description": "Updated phone numbers. Provide an empty array to remove all numbers.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomerPhoneNumberDto"
+            }
+          },
+          "privacySettings": {
+            "description": "Updated privacy preferences.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CustomerPrivacySettingsDto"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/openapi/openapi.yaml
+++ b/api/openapi/openapi.yaml
@@ -1,0 +1,382 @@
+openapi: 3.0.0
+paths:
+  /health:
+    get:
+      operationId: HealthController_health
+      parameters: []
+      responses:
+        "200":
+          description: ""
+      tags: &a1
+        - Health
+  /health/live:
+    get:
+      operationId: HealthController_liveness
+      parameters: []
+      responses:
+        "200":
+          description: ""
+      tags: *a1
+  /health/ready:
+    get:
+      operationId: HealthController_readiness
+      parameters: []
+      responses:
+        "200":
+          description: ""
+      tags: *a1
+  /customers:
+    get:
+      operationId: CustomerController_listCustomers
+      parameters: []
+      responses:
+        "200":
+          description: A collection of customers.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ResponseCustomerDto"
+      summary: List customers
+      tags: &a2
+        - Customer
+    post:
+      operationId: CustomerController_createCustomer
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateCustomerDto"
+      responses:
+        "201":
+          description: Customer successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseCustomerDto"
+        "400":
+          description: Invalid payload supplied.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+      summary: Create a new customer
+      tags: *a2
+  /customers/{id}:
+    get:
+      operationId: CustomerController_getCustomer
+      parameters:
+        - name: id
+          required: true
+          in: path
+          description: Customer identifier
+          schema:
+            example: 8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a
+            type: string
+      responses:
+        "200":
+          description: Customer found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseCustomerDto"
+        "404":
+          description: Customer not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+      summary: Fetch a customer by identifier
+      tags: *a2
+    put:
+      operationId: CustomerController_updateCustomer
+      parameters:
+        - name: id
+          required: true
+          in: path
+          description: Customer identifier
+          schema:
+            example: 8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateCustomerDto"
+      responses:
+        "200":
+          description: Customer successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseCustomerDto"
+        "400":
+          description: Invalid payload supplied.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "404":
+          description: Customer not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+      summary: Update an existing customer
+      tags: *a2
+    delete:
+      operationId: CustomerController_deleteCustomer
+      parameters:
+        - name: id
+          required: true
+          in: path
+          description: Customer identifier
+          schema:
+            example: 8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a
+            type: string
+      responses:
+        "204":
+          description: Customer deleted successfully.
+        "404":
+          description: Customer not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+      summary: Delete an existing customer
+      tags: *a2
+info:
+  title: Customer Registration API
+  description: HTTP API for managing the customer onboarding lifecycle.
+  version: 0.0.1
+  contact: {}
+tags:
+  - name: Customer
+    description: ""
+servers: []
+components:
+  schemas:
+    ProblemDetail:
+      type: object
+      properties:
+        statusCode:
+          type: number
+          example: 400
+          description: HTTP status code for the error response.
+        error:
+          type: string
+          example: Bad Request
+          description: Short error classification or reason phrase.
+        message:
+          type: object
+          example: Validation failed for the submitted payload.
+          description: Human readable error message or summary.
+        path:
+          type: string
+          example: /customers
+          description: Request path that triggered the error.
+        timestamp:
+          type: string
+          example: 2025-09-30T17:20:00.000Z
+          description: UTC timestamp when the error was generated.
+      required:
+        - statusCode
+        - error
+        - message
+        - path
+        - timestamp
+    CustomerPhoneNumberDto:
+      type: object
+      properties:
+        type:
+          type: string
+          description: Type of phone number
+          example: mobile
+          enum:
+            - mobile
+            - home
+            - work
+            - other
+        number:
+          type: string
+          description: Phone number in E.164 format
+          example: "+15558675309"
+      required:
+        - type
+        - number
+    CustomerAddressDto:
+      type: object
+      properties:
+        line1:
+          type: string
+          description: Street address, P.O. box, company name, c/o
+          example: 123 Main St
+        line2:
+          type: object
+          description: Apartment, suite, unit, building, floor, etc.
+          example: Apt 4B
+        city:
+          type: string
+          description: City or locality
+          example: Springfield
+        state:
+          type: string
+          description: State, province, or region
+          example: IL
+        postalCode:
+          type: string
+          description: ZIP or postal code
+          example: "62704"
+        country:
+          type: string
+          description: ISO 3166-1 alpha-2 country code
+          example: US
+      required:
+        - line1
+        - city
+        - state
+        - postalCode
+        - country
+    CustomerPrivacySettingsDto:
+      type: object
+      properties:
+        marketingEmailsEnabled:
+          type: boolean
+          description: Whether the customer opts in to marketing emails.
+          example: true
+        twoFactorEnabled:
+          type: boolean
+          description: Whether the customer has two-factor authentication enabled.
+          example: true
+      required:
+        - marketingEmailsEnabled
+        - twoFactorEnabled
+    ResponseCustomerDto:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique identifier for the customer profile.
+          example: 8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a
+        firstName:
+          type: string
+          description: Customer's given name.
+          example: Jane
+        middleName:
+          type: object
+          description: Customer's middle name or initial.
+          example: Alexandra
+          nullable: true
+        lastName:
+          type: string
+          description: Customer's family name.
+          example: Doe
+        emails:
+          description: List of the customer's email addresses.
+          type: array
+          items:
+            type: string
+        phoneNumbers:
+          description: List of the customer's phone numbers.
+          type: array
+          items:
+            $ref: "#/components/schemas/CustomerPhoneNumberDto"
+        address:
+          description: Postal address of the customer.
+          nullable: true
+          allOf:
+            - $ref: "#/components/schemas/CustomerAddressDto"
+        privacySettings:
+          description: Customer privacy preferences.
+          allOf:
+            - $ref: "#/components/schemas/CustomerPrivacySettingsDto"
+      required:
+        - id
+        - firstName
+        - lastName
+        - emails
+        - privacySettings
+    CreateCustomerDto:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique identifier for the customer profile.
+          example: 8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a
+        firstName:
+          type: string
+          description: Customer's given name.
+          example: Jane
+        middleName:
+          type: object
+          description: Customer's middle name or initial.
+          example: Alexandra
+        lastName:
+          type: string
+          description: Customer's family name.
+          example: Doe
+        emails:
+          description: List of the customer's email addresses.
+          example: &a3
+            - jane.doe@example.com
+          type: array
+          items:
+            type: string
+        phoneNumbers:
+          description: List of the customer's phone numbers.
+          type: array
+          items:
+            $ref: "#/components/schemas/CustomerPhoneNumberDto"
+        address:
+          description: Postal address of the customer.
+          allOf:
+            - $ref: "#/components/schemas/CustomerAddressDto"
+        privacySettings:
+          description: Customer privacy preferences.
+          allOf:
+            - $ref: "#/components/schemas/CustomerPrivacySettingsDto"
+      required:
+        - id
+        - firstName
+        - lastName
+        - emails
+        - privacySettings
+    UpdateCustomerDto:
+      type: object
+      properties:
+        firstName:
+          type: string
+          description: Customer's given name.
+          example: Jane
+        middleName:
+          type: object
+          description: Customer's middle name or initial.
+          example: Alexandra
+        lastName:
+          type: string
+          description: Customer's family name.
+          example: Doe
+        emails:
+          description: List of the customer's email addresses.
+          example: *a3
+          type: array
+          items:
+            type: string
+        address:
+          description: Updated postal address. Provide `null` to remove the current address.
+          nullable: true
+          allOf:
+            - $ref: "#/components/schemas/CustomerAddressDto"
+        phoneNumbers:
+          description: Updated phone numbers. Provide an empty array to remove all numbers.
+          type: array
+          items:
+            $ref: "#/components/schemas/CustomerPhoneNumberDto"
+        privacySettings:
+          description: Updated privacy preferences.
+          allOf:
+            - $ref: "#/components/schemas/CustomerPrivacySettingsDto"

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -41,13 +41,15 @@
         "eslint": "^9.28.0",
         "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-prettier": "^5.4.1",
+        "pg-mem": "^3.0.5",
         "prettier": "^3.5.3",
         "source-map-support": "^0.5.21",
         "supertest": "^7.1.1",
         "ts-jest": "^29.3.4",
         "ts-loader": "^9.5.2",
         "ts-node": "^10.9.2",
-        "typescript": "^5.8.3"
+        "typescript": "^5.8.3",
+        "yaml": "^2.7.0"
       }
     },
     "node_modules/@angular-devkit/core": {
@@ -5191,6 +5193,13 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dotenv": {
       "version": "16.4.7",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
@@ -6254,6 +6263,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -6627,6 +6643,13 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immutable": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
+      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -8580,6 +8603,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -8618,6 +8661,16 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/keyv": {
@@ -8992,6 +9045,23 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moo": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -9093,6 +9163,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
+    },
+    "node_modules/nearley/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -9175,6 +9275,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -9185,6 +9295,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/on-finished": {
@@ -9504,6 +9624,85 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/pg-mem": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/pg-mem/-/pg-mem-3.0.5.tgz",
+      "integrity": "sha512-Bh8xHD6u/wUXCoyFE2vyRs5pgaKbqjWFQowKDlbKWCiF0vOlo2A0PZdiUxmf2PKgb6Vb6C7gwAlA7jKvsfDHZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "functional-red-black-tree": "^1.0.1",
+        "immutable": "^4.3.4",
+        "json-stable-stringify": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "moment": "^2.27.0",
+        "object-hash": "^2.0.3",
+        "pgsql-ast-parser": "^12.0.1"
+      },
+      "peerDependencies": {
+        "@mikro-orm/core": ">=4.5.3",
+        "@mikro-orm/postgresql": ">=4.5.3",
+        "knex": ">=0.20",
+        "kysely": ">=0.26",
+        "pg-promise": ">=10.8.7",
+        "pg-server": "^0.1.5",
+        "postgres": "^3.4.4",
+        "slonik": ">=23.0.1",
+        "typeorm": ">=0.2.29"
+      },
+      "peerDependenciesMeta": {
+        "@mikro-orm/core": {
+          "optional": true
+        },
+        "@mikro-orm/postgresql": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mikro-orm": {
+          "optional": true
+        },
+        "pg-promise": {
+          "optional": true
+        },
+        "pg-server": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "slonik": {
+          "optional": true
+        },
+        "typeorm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-mem/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pg-mem/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/pg-pool": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
@@ -9542,6 +9741,17 @@
       "license": "MIT",
       "dependencies": {
         "split2": "^4.1.0"
+      }
+    },
+    "node_modules/pgsql-ast-parser": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/pgsql-ast-parser/-/pgsql-ast-parser-12.0.1.tgz",
+      "integrity": "sha512-pe8C6Zh5MsS+o38WlSu18NhrTjAv1UNMeDTs2/Km2ZReZdYBYtwtbWGZKK2BM2izv5CrQpbmP0oI10wvHOwv4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "moo": "^0.5.1",
+        "nearley": "^2.19.5"
       }
     },
     "node_modules/picocolors": {
@@ -9877,6 +10087,27 @@
       ],
       "license": "MIT"
     },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -10036,6 +10267,16 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
+      }
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -10457,6 +10698,14 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/sql.js": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.13.0.tgz",
+      "integrity": "sha512-RJbVP1HRDlUUXahJ7VMTcu9Rm1Nzw+EBpoPr94vnbD4LwR715F3CcxE2G2k45PewcaZ57pjetYa+LoSJLAASgA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -12121,6 +12370,19 @@
       "dev": true,
       "license": "ISC",
       "peer": true
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/api/package.json
+++ b/api/package.json
@@ -18,6 +18,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
+    "openapi:emit": "ts-node -r tsconfig-paths/register src/scripts/emit-openapi.ts",
     "db:validate": "dotenv -e ../ai/context/.env -e .env -- ts-node src/database/validate-connection.ts",
     "typeorm:migration:create": "dotenv -e ../ai/context/.env -e .env -- typeorm migration:create src/migrations/Manual",
     "migration:run": "npx ts-node -P ./tsconfig.json -r tsconfig-paths/register ./node_modules/typeorm/cli.js migration:run -d ./src/database/data-source.ts",
@@ -54,6 +55,7 @@
     "@types/jest": "^29.5.14",
     "@types/node": "^22.15.30",
     "@types/supertest": "^6.0.3",
+    "pg-mem": "^3.0.5",
     "@typescript-eslint/eslint-plugin": "^8.33.1",
     "@typescript-eslint/parser": "^8.33.1",
     "dotenv-cli": "^7.3.0",
@@ -66,6 +68,7 @@
     "ts-jest": "^29.3.4",
     "ts-loader": "^9.5.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "yaml": "^2.7.0"
   }
 }

--- a/api/src/common/http/http-exception.filter.ts
+++ b/api/src/common/http/http-exception.filter.ts
@@ -1,0 +1,75 @@
+/**
+ * # App: Customer Registration API
+ * # Package: api/src/common/http
+ * # File: http-exception.filter.ts
+ * # Version: 0.1.0
+ * # Turns: 4
+ * # Author: Codex Agent
+ * # Date: 2025-09-30T18:10:00Z
+ * # Exports: HttpExceptionFilter
+ * # Description: Implements a global exception filter translating NestJS exceptions into Problem Detail responses
+ * #              while emitting structured logs for diagnostics.
+ */
+import { ArgumentsHost, Catch, ExceptionFilter, HttpException, HttpStatus } from '@nestjs/common';
+import { HttpAdapterHost } from '@nestjs/core';
+import { Request } from 'express';
+import { JsonLogger } from '../logging/json-logger.service';
+import { ProblemDetail } from './problem-detail';
+
+@Catch()
+export class HttpExceptionFilter implements ExceptionFilter {
+  constructor(
+    private readonly httpAdapterHost: HttpAdapterHost,
+    private readonly logger: JsonLogger,
+  ) {}
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const { httpAdapter } = this.httpAdapterHost;
+    const context = host.switchToHttp();
+    const request = context.getRequest<Request & { path?: string }>();
+    const status = this.resolveStatus(exception);
+    const problem = this.buildProblemDetail(exception, status, request?.path ?? request?.url ?? 'unknown');
+
+    if (status >= HttpStatus.INTERNAL_SERVER_ERROR) {
+      this.logger.error({ message: 'Unhandled exception', exception }, undefined, 'HttpExceptionFilter');
+    } else {
+      this.logger.warn({ message: 'HTTP exception', exception, status }, 'HttpExceptionFilter');
+    }
+
+    httpAdapter.reply(context.getResponse(), problem, status);
+  }
+
+  private resolveStatus(exception: unknown): number {
+    if (exception instanceof HttpException) {
+      return exception.getStatus();
+    }
+
+    return HttpStatus.INTERNAL_SERVER_ERROR;
+  }
+
+  private buildProblemDetail(exception: unknown, status: number, path: string): ProblemDetail {
+    if (exception instanceof HttpException) {
+      const response = exception.getResponse();
+      const { message, error } =
+        typeof response === 'string'
+          ? { message: response, error: exception.name }
+          : (response as { message?: string | string[]; error?: string });
+
+      return {
+        statusCode: status,
+        error: error ?? exception.name,
+        message: message ?? exception.message,
+        path,
+        timestamp: new Date().toISOString(),
+      };
+    }
+
+    return {
+      statusCode: status,
+      error: 'InternalServerError',
+      message: 'An unexpected error occurred.',
+      path,
+      timestamp: new Date().toISOString(),
+    };
+  }
+}

--- a/api/src/common/http/index.ts
+++ b/api/src/common/http/index.ts
@@ -1,0 +1,13 @@
+/**
+ * # App: Customer Registration API
+ * # Package: api/src/common/http
+ * # File: index.ts
+ * # Version: 0.1.0
+ * # Turns: 4
+ * # Author: Codex Agent
+ * # Date: 2025-09-30T18:10:00Z
+ * # Exports: *
+ * # Description: Re-exports HTTP utility modules including the Problem Detail DTO and global exception filter.
+ */
+export * from './http-exception.filter';
+export * from './problem-detail';

--- a/api/src/common/http/problem-detail.ts
+++ b/api/src/common/http/problem-detail.ts
@@ -1,0 +1,36 @@
+/**
+ * # App: Customer Registration API
+ * # Package: api/src/common/http
+ * # File: problem-detail.ts
+ * # Version: 0.1.0
+ * # Turns: 4
+ * # Author: Codex Agent
+ * # Date: 2025-09-30T18:10:00Z
+ * # Exports: ProblemDetail
+ * # Description: Defines the RFC7807-inspired Problem Details response envelope documented in Swagger and
+ * #              returned by the global HTTP exception filter.
+ */
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ProblemDetail {
+  @ApiProperty({ example: 400, description: 'HTTP status code for the error response.' })
+  statusCode!: number;
+
+  @ApiProperty({ example: 'Bad Request', description: 'Short error classification or reason phrase.' })
+  error!: string;
+
+  @ApiProperty({
+    example: 'Validation failed for the submitted payload.',
+    description: 'Human readable error message or summary.',
+  })
+  message!: string | string[];
+
+  @ApiProperty({ example: '/customers', description: 'Request path that triggered the error.' })
+  path!: string;
+
+  @ApiProperty({
+    example: '2025-09-30T17:20:00.000Z',
+    description: 'UTC timestamp when the error was generated.',
+  })
+  timestamp!: string;
+}

--- a/api/src/customer/controllers/customer.controller.spec.ts
+++ b/api/src/customer/controllers/customer.controller.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * # App: Customer Registration API
+ * # Package: api/src/customer/controllers
+ * # File: customer.controller.spec.ts
+ * # Version: 0.1.0
+ * # Turns: 4
+ * # Author: Codex Agent
+ * # Date: 2025-09-30T18:10:00Z
+ * # Description: Unit tests verifying the customer controller orchestrates CRUD flows and error handling in
+ * #              concert with the customer service.
+ * #
+ * # Test Suites
+ * # - CustomerController: Covers list, read, create, update, and delete scenarios with success and 404 cases.
+ */
+import { Test } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { CustomerController } from './customer.controller';
+import { CustomerService } from '../services/customer.service';
+import { CustomerEntity } from '../entities';
+
+const createCustomerEntity = (overrides: Partial<CustomerEntity> = {}): CustomerEntity => ({
+  customerId: '8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a',
+  firstName: 'Jane',
+  middleName: 'Q',
+  lastName: 'Doe',
+  emails: [],
+  phoneNumbers: [],
+  address: null,
+  privacySettings: {
+    privacySettingsId: 1,
+    marketingEmailsEnabled: true,
+    twoFactorEnabled: true,
+    customers: [],
+  },
+  addressId: null,
+  privacySettingsId: 1,
+  ...overrides,
+});
+
+describe('CustomerController', () => {
+  let controller: CustomerController;
+  let service: jest.Mocked<CustomerService>;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [CustomerController],
+      providers: [
+        {
+          provide: CustomerService,
+          useValue: {
+            listCustomers: jest.fn(),
+            findCustomerById: jest.fn(),
+            createCustomer: jest.fn(),
+            updateCustomerProfile: jest.fn(),
+            deleteCustomer: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = moduleRef.get(CustomerController);
+    service = moduleRef.get(CustomerService) as jest.Mocked<CustomerService>;
+  });
+
+  it('lists customers', async () => {
+    service.listCustomers.mockResolvedValue([
+      createCustomerEntity({
+        emails: [
+          {
+            emailId: 1,
+            email: 'jane.doe@example.com',
+            customerId: '1',
+            customer: undefined as never,
+          } as unknown as CustomerEntity['emails'][number],
+        ],
+        phoneNumbers: [
+          {
+            phoneId: 1,
+            type: 'mobile',
+            number: '+15558675309',
+            customerId: '1',
+            customer: undefined as never,
+          } as unknown as CustomerEntity['phoneNumbers'][number],
+        ],
+      }),
+    ]);
+
+    const result = await controller.listCustomers();
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: '8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a',
+        emails: ['jane.doe@example.com'],
+        phoneNumbers: [{ type: 'mobile', number: '+15558675309' }],
+      }),
+    ]);
+  });
+
+  it('returns a single customer', async () => {
+    service.findCustomerById.mockResolvedValue(createCustomerEntity());
+
+    const result = await controller.getCustomer('8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a');
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        id: '8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a',
+        firstName: 'Jane',
+      }),
+    );
+  });
+
+  it('throws NotFound for missing customer', async () => {
+    service.findCustomerById.mockResolvedValue(null);
+
+    await expect(controller.getCustomer('8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a')).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('creates a customer', async () => {
+    service.createCustomer.mockResolvedValue(createCustomerEntity());
+
+    const result = await controller.createCustomer({
+      id: '8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a',
+      firstName: 'Jane',
+      lastName: 'Doe',
+      middleName: 'Q',
+      emails: ['jane.doe@example.com'],
+      privacySettings: { marketingEmailsEnabled: true, twoFactorEnabled: true },
+    });
+
+    expect(service.createCustomer).toHaveBeenCalledWith(
+      expect.objectContaining({ customerId: '8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a' }),
+    );
+    expect(result).toEqual(expect.objectContaining({ id: '8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a' }));
+  });
+
+  it('updates a customer', async () => {
+    service.updateCustomerProfile.mockResolvedValue(createCustomerEntity({ firstName: 'Janet' }));
+
+    const result = await controller.updateCustomer('8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a', {
+      firstName: 'Janet',
+    });
+
+    expect(service.updateCustomerProfile).toHaveBeenCalledWith('8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a', expect.any(Object));
+    expect(result.firstName).toBe('Janet');
+  });
+
+  it('deletes a customer', async () => {
+    service.findCustomerById.mockResolvedValue(createCustomerEntity());
+
+    await controller.deleteCustomer('8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a');
+
+    expect(service.deleteCustomer).toHaveBeenCalledWith('8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a');
+  });
+});

--- a/api/src/customer/controllers/customer.controller.ts
+++ b/api/src/customer/controllers/customer.controller.ts
@@ -1,0 +1,200 @@
+/**
+ * # App: Customer Registration API
+ * # Package: api/src/customer/controllers
+ * # File: customer.controller.ts
+ * # Version: 0.1.0
+ * # Turns: 4
+ * # Author: Codex Agent
+ * # Date: 2025-09-30T18:10:00Z
+ * # Exports: CustomerController
+ * # Description: Exposes RESTful CRUD endpoints for customer resources including list, fetch, create,
+ * #              update, and delete operations with Problem Details error responses and Swagger metadata.
+ */
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  NotFoundException,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Put,
+} from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiCreatedResponse,
+  ApiExtraModels,
+  ApiNoContentResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+} from '@nestjs/swagger';
+import { CustomerEntity } from '../entities';
+import {
+  CreateCustomerPayload,
+  CustomerService,
+  UpdateCustomerProfilePayload,
+} from '../services/customer.service';
+import {
+  CreateCustomerDto,
+  CustomerAddressDto,
+  CustomerPhoneNumberDto,
+  CustomerPrivacySettingsDto,
+} from '../dtos/create-customer.dto';
+import { UpdateCustomerDto } from '../dtos/update-customer.dto';
+import { ResponseCustomerDto } from '../dtos/response-customer.dto';
+import { ProblemDetail } from '../../common/http/problem-detail';
+
+@ApiTags('Customer')
+@ApiExtraModels(
+  ProblemDetail,
+  ResponseCustomerDto,
+  CustomerAddressDto,
+  CustomerPhoneNumberDto,
+  CustomerPrivacySettingsDto,
+)
+@Controller('customers')
+export class CustomerController {
+  constructor(private readonly customerService: CustomerService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List customers' })
+  @ApiOkResponse({ description: 'A collection of customers.', type: ResponseCustomerDto, isArray: true })
+  async listCustomers(): Promise<ResponseCustomerDto[]> {
+    const customers = await this.customerService.listCustomers();
+    return customers.map((customer) => CustomerController.toResponseDto(customer));
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Fetch a customer by identifier' })
+  @ApiParam({ name: 'id', type: String, description: 'Customer identifier', example: '8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a' })
+  @ApiOkResponse({ description: 'Customer found.', type: ResponseCustomerDto })
+  @ApiNotFoundResponse({ description: 'Customer not found.', type: ProblemDetail })
+  async getCustomer(
+    @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
+  ): Promise<ResponseCustomerDto> {
+    const customer = await this.customerService.findCustomerById(id);
+    if (!customer) {
+      throw new NotFoundException(`Customer with id ${id} not found`);
+    }
+
+    return CustomerController.toResponseDto(customer);
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Create a new customer' })
+  @ApiCreatedResponse({ description: 'Customer successfully created.', type: ResponseCustomerDto })
+  @ApiBadRequestResponse({ description: 'Invalid payload supplied.', type: ProblemDetail })
+  async createCustomer(@Body() payload: CreateCustomerDto): Promise<ResponseCustomerDto> {
+    const createPayload: CreateCustomerPayload = {
+      customerId: payload.id,
+      firstName: payload.firstName,
+      middleName: payload.middleName ?? null,
+      lastName: payload.lastName,
+      privacySettings: payload.privacySettings,
+      emails: payload.emails,
+    };
+
+    if (payload.address) {
+      createPayload.address = payload.address;
+    }
+
+    if (payload.phoneNumbers) {
+      createPayload.phoneNumbers = payload.phoneNumbers;
+    }
+
+    const entity = await this.customerService.createCustomer(createPayload);
+
+    return CustomerController.toResponseDto(entity);
+  }
+
+  @Put(':id')
+  @ApiOperation({ summary: 'Update an existing customer' })
+  @ApiParam({ name: 'id', type: String, description: 'Customer identifier', example: '8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a' })
+  @ApiOkResponse({ description: 'Customer successfully updated.', type: ResponseCustomerDto })
+  @ApiBadRequestResponse({ description: 'Invalid payload supplied.', type: ProblemDetail })
+  @ApiNotFoundResponse({ description: 'Customer not found.', type: ProblemDetail })
+  async updateCustomer(
+    @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
+    @Body() payload: UpdateCustomerDto,
+  ): Promise<ResponseCustomerDto> {
+    const changes: UpdateCustomerProfilePayload = {};
+
+    if (payload.firstName !== undefined) {
+      changes.firstName = payload.firstName;
+    }
+    if (payload.middleName !== undefined) {
+      changes.middleName = payload.middleName ?? null;
+    }
+    if (payload.lastName !== undefined) {
+      changes.lastName = payload.lastName;
+    }
+    if (payload.address !== undefined) {
+      changes.address = payload.address;
+    }
+    if (payload.privacySettings !== undefined) {
+      changes.privacySettings = payload.privacySettings;
+    }
+    if (payload.emails !== undefined) {
+      changes.emails = payload.emails;
+    }
+    if (payload.phoneNumbers !== undefined) {
+      changes.phoneNumbers = payload.phoneNumbers;
+    }
+
+    const entity = await this.customerService.updateCustomerProfile(id, changes);
+
+    return CustomerController.toResponseDto(entity);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete an existing customer' })
+  @ApiParam({ name: 'id', type: String, description: 'Customer identifier', example: '8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a' })
+  @ApiNoContentResponse({ description: 'Customer deleted successfully.' })
+  @ApiNotFoundResponse({ description: 'Customer not found.', type: ProblemDetail })
+  async deleteCustomer(
+    @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
+  ): Promise<void> {
+    const existing = await this.customerService.findCustomerById(id);
+    if (!existing) {
+      throw new NotFoundException(`Customer with id ${id} not found`);
+    }
+
+    await this.customerService.deleteCustomer(id);
+  }
+
+  private static toResponseDto(entity: CustomerEntity): ResponseCustomerDto {
+    return {
+      id: entity.customerId,
+      firstName: entity.firstName,
+      middleName: entity.middleName,
+      lastName: entity.lastName,
+      emails: entity.emails?.map((email) => email.email) ?? [],
+      phoneNumbers:
+        entity.phoneNumbers?.map((phone) => ({
+          type: phone.type,
+          number: phone.number,
+        })) ?? [],
+      address: entity.address
+        ? {
+            line1: entity.address.line1,
+            line2: entity.address.line2,
+            city: entity.address.city,
+            state: entity.address.state,
+            postalCode: entity.address.postalCode,
+            country: entity.address.country,
+          }
+        : null,
+      privacySettings: {
+        marketingEmailsEnabled: entity.privacySettings.marketingEmailsEnabled,
+        twoFactorEnabled: entity.privacySettings.twoFactorEnabled,
+      },
+    };
+  }
+}

--- a/api/src/customer/customer.module.ts
+++ b/api/src/customer/customer.module.ts
@@ -2,19 +2,21 @@
  * # App: Customer Registration API
  * # Package: api/src/customer
  * # File: customer.module.ts
- * # Version: 0.1.0
- * # Turns: 3
+ * # Version: 0.2.0
+ * # Turns: 3,4
  * # Author: Codex Agent
- * # Date: 2025-09-30T17:20:00Z
+ * # Date: 2025-09-30T18:10:00Z
  * # Exports: CustomerModule
- * # Description: Nest module wiring customer persistence services and database bindings.
+ * # Description: Nest module wiring customer persistence services, controller, and database bindings.
  */
 import { Module } from '@nestjs/common';
 import { CustomerDatabaseModule } from './database/customer-database.module';
 import { CustomerService } from './services/customer.service';
+import { CustomerController } from './controllers/customer.controller';
 
 @Module({
   imports: [CustomerDatabaseModule],
+  controllers: [CustomerController],
   providers: [CustomerService],
   exports: [CustomerService, CustomerDatabaseModule],
 })

--- a/api/src/customer/dtos/create-customer.dto.spec.ts
+++ b/api/src/customer/dtos/create-customer.dto.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * # App: Customer Registration API
+ * # Package: api/src/customer/dtos
+ * # File: create-customer.dto.spec.ts
+ * # Version: 0.1.0
+ * # Turns: 4
+ * # Author: Codex Agent
+ * # Date: 2025-09-30T18:10:00Z
+ * # Description: Unit tests validating CreateCustomerDto transformation and validation constraints using
+ * #              class-validator to ensure schema compliance.
+ * #
+ * # Test Suites
+ * # - CreateCustomerDto: Confirms acceptance of valid payloads and rejection of malformed inputs.
+ */
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { CreateCustomerDto } from './create-customer.dto';
+
+describe('CreateCustomerDto', () => {
+  it('validates a correct payload', async () => {
+    const dto = plainToInstance(CreateCustomerDto, {
+      id: '8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a',
+      firstName: 'Jane',
+      middleName: 'Q',
+      lastName: 'Doe',
+      emails: ['jane.doe@example.com'],
+      phoneNumbers: [{ type: 'mobile', number: '+15558675309' }],
+      address: {
+        line1: '123 Main St',
+        city: 'Springfield',
+        state: 'IL',
+        postalCode: '62704',
+        country: 'US',
+      },
+      privacySettings: { marketingEmailsEnabled: true, twoFactorEnabled: false },
+    });
+
+    await expect(validate(dto)).resolves.toHaveLength(0);
+  });
+
+  it('flags missing required properties', async () => {
+    const dto = plainToInstance(CreateCustomerDto, {
+      id: 'invalid',
+      firstName: '',
+      lastName: '',
+      emails: [],
+      privacySettings: {},
+    });
+
+    const errors = await validate(dto);
+    expect(errors).not.toHaveLength(0);
+  });
+});

--- a/api/src/customer/dtos/create-customer.dto.ts
+++ b/api/src/customer/dtos/create-customer.dto.ts
@@ -1,0 +1,135 @@
+/**
+ * # App: Customer Registration API
+ * # Package: api/src/customer/dtos
+ * # File: create-customer.dto.ts
+ * # Version: 0.1.0
+ * # Turns: 4
+ * # Author: Codex Agent
+ * # Date: 2025-09-30T18:10:00Z
+ * # Exports: CustomerPrivacySettingsDto, CustomerAddressDto, CustomerPhoneNumberDto, CreateCustomerDto
+ * # Description: Defines request payload structures for creating customers, including nested address, phone,
+ * #              and privacy preference DTOs with validation and Swagger metadata annotations.
+ */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  ArrayMinSize,
+  ArrayUnique,
+  IsArray,
+  IsBoolean,
+  IsEmail,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Matches,
+  MaxLength,
+  MinLength,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class CustomerPrivacySettingsDto {
+  @ApiProperty({ description: 'Whether the customer opts in to marketing emails.', example: true })
+  @IsBoolean()
+  marketingEmailsEnabled!: boolean;
+
+  @ApiProperty({ description: 'Whether the customer has two-factor authentication enabled.', example: true })
+  @IsBoolean()
+  twoFactorEnabled!: boolean;
+}
+
+export class CustomerAddressDto {
+  @ApiProperty({ description: 'Street address, P.O. box, company name, c/o', example: '123 Main St' })
+  @IsString()
+  @IsNotEmpty()
+  line1!: string;
+
+  @ApiPropertyOptional({ description: 'Apartment, suite, unit, building, floor, etc.', example: 'Apt 4B' })
+  @IsOptional()
+  @IsString()
+  line2?: string | null;
+
+  @ApiProperty({ description: 'City or locality', example: 'Springfield' })
+  @IsString()
+  @IsNotEmpty()
+  city!: string;
+
+  @ApiProperty({ description: 'State, province, or region', example: 'IL' })
+  @IsString()
+  @IsNotEmpty()
+  state!: string;
+
+  @ApiProperty({ description: 'ZIP or postal code', example: '62704' })
+  @IsString()
+  @IsNotEmpty()
+  postalCode!: string;
+
+  @ApiProperty({ description: 'ISO 3166-1 alpha-2 country code', example: 'US' })
+  @IsString()
+  @MinLength(2)
+  @MaxLength(2)
+  country!: string;
+}
+
+export class CustomerPhoneNumberDto {
+  @ApiProperty({ description: 'Type of phone number', example: 'mobile', enum: ['mobile', 'home', 'work', 'other'] })
+  @IsString()
+  @IsNotEmpty()
+  type!: string;
+
+  @ApiProperty({ description: 'Phone number in E.164 format', example: '+15558675309' })
+  @IsString()
+  @Matches(/^\+?[1-9]\d{1,14}$/)
+  number!: string;
+}
+
+export class CreateCustomerDto {
+  @ApiProperty({ description: 'Unique identifier for the customer profile.', example: '8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a' })
+  @IsUUID()
+  id!: string;
+
+  @ApiProperty({ description: 'Customer\'s given name.', example: 'Jane' })
+  @IsString()
+  @IsNotEmpty()
+  firstName!: string;
+
+  @ApiPropertyOptional({ description: 'Customer\'s middle name or initial.', example: 'Alexandra' })
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  middleName?: string | null;
+
+  @ApiProperty({ description: 'Customer\'s family name.', example: 'Doe' })
+  @IsString()
+  @IsNotEmpty()
+  lastName!: string;
+
+  @ApiProperty({ description: 'List of the customer\'s email addresses.', type: [String], example: ['jane.doe@example.com'] })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayUnique()
+  @IsEmail({}, { each: true })
+  emails!: string[];
+
+  @ApiPropertyOptional({
+    description: 'List of the customer\'s phone numbers.',
+    type: () => [CustomerPhoneNumberDto],
+  })
+  @IsOptional()
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => CustomerPhoneNumberDto)
+  phoneNumbers?: CustomerPhoneNumberDto[];
+
+  @ApiPropertyOptional({ description: 'Postal address of the customer.', type: () => CustomerAddressDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CustomerAddressDto)
+  address?: CustomerAddressDto;
+
+  @ApiProperty({ description: 'Customer privacy preferences.', type: () => CustomerPrivacySettingsDto })
+  @ValidateNested()
+  @Type(() => CustomerPrivacySettingsDto)
+  privacySettings!: CustomerPrivacySettingsDto;
+}

--- a/api/src/customer/dtos/response-customer.dto.ts
+++ b/api/src/customer/dtos/response-customer.dto.ts
@@ -1,0 +1,44 @@
+/**
+ * # App: Customer Registration API
+ * # Package: api/src/customer/dtos
+ * # File: response-customer.dto.ts
+ * # Version: 0.1.0
+ * # Turns: 4
+ * # Author: Codex Agent
+ * # Date: 2025-09-30T18:10:00Z
+ * # Exports: ResponseCustomerDto
+ * # Description: Represents the serialized customer payload returned from REST endpoints with Swagger metadata
+ * #              to document identifiers, contact methods, address, and privacy preferences.
+ */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  CustomerAddressDto,
+  CustomerPhoneNumberDto,
+  CustomerPrivacySettingsDto,
+} from './create-customer.dto';
+
+export class ResponseCustomerDto {
+  @ApiProperty({ description: 'Unique identifier for the customer profile.', example: '8d5b1c5b-4744-45f5-9a65-8eaa0fbecf2a' })
+  id!: string;
+
+  @ApiProperty({ description: 'Customer\'s given name.', example: 'Jane' })
+  firstName!: string;
+
+  @ApiPropertyOptional({ description: 'Customer\'s middle name or initial.', example: 'Alexandra', nullable: true })
+  middleName!: string | null;
+
+  @ApiProperty({ description: 'Customer\'s family name.', example: 'Doe' })
+  lastName!: string;
+
+  @ApiProperty({ description: 'List of the customer\'s email addresses.', type: [String] })
+  emails!: string[];
+
+  @ApiPropertyOptional({ description: 'List of the customer\'s phone numbers.', type: () => [CustomerPhoneNumberDto] })
+  phoneNumbers!: CustomerPhoneNumberDto[];
+
+  @ApiPropertyOptional({ description: 'Postal address of the customer.', type: () => CustomerAddressDto, nullable: true })
+  address!: CustomerAddressDto | null;
+
+  @ApiProperty({ description: 'Customer privacy preferences.', type: () => CustomerPrivacySettingsDto })
+  privacySettings!: CustomerPrivacySettingsDto;
+}

--- a/api/src/customer/dtos/update-customer.dto.ts
+++ b/api/src/customer/dtos/update-customer.dto.ts
@@ -1,0 +1,50 @@
+/**
+ * # App: Customer Registration API
+ * # Package: api/src/customer/dtos
+ * # File: update-customer.dto.ts
+ * # Version: 0.1.0
+ * # Turns: 4
+ * # Author: Codex Agent
+ * # Date: 2025-09-30T18:10:00Z
+ * # Exports: UpdateCustomerDto
+ * # Description: Extends the create customer DTO to support partial updates, capturing optional address,
+ * #              phone, and privacy changes for PUT operations with validation metadata.
+ */
+import { ApiPropertyOptional, PartialType, OmitType } from '@nestjs/swagger';
+import { IsOptional, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import {
+  CreateCustomerDto,
+  CustomerAddressDto,
+  CustomerPhoneNumberDto,
+  CustomerPrivacySettingsDto,
+} from './create-customer.dto';
+
+export class UpdateCustomerDto extends PartialType(
+  OmitType(CreateCustomerDto, ['id', 'address', 'phoneNumbers', 'privacySettings'] as const),
+) {
+  @ApiPropertyOptional({
+    description: 'Updated postal address. Provide `null` to remove the current address.',
+    type: () => CustomerAddressDto,
+    nullable: true,
+  })
+  @ValidateNested()
+  @Type(() => CustomerAddressDto)
+  @IsOptional()
+  declare address?: CustomerAddressDto | null;
+
+  @ApiPropertyOptional({
+    description: 'Updated phone numbers. Provide an empty array to remove all numbers.',
+    type: () => [CustomerPhoneNumberDto],
+  })
+  @ValidateNested({ each: true })
+  @Type(() => CustomerPhoneNumberDto)
+  @IsOptional()
+  declare phoneNumbers?: CustomerPhoneNumberDto[];
+
+  @ApiPropertyOptional({ description: 'Updated privacy preferences.', type: () => CustomerPrivacySettingsDto })
+  @ValidateNested()
+  @Type(() => CustomerPrivacySettingsDto)
+  @IsOptional()
+  declare privacySettings?: CustomerPrivacySettingsDto;
+}

--- a/api/src/customer/services/customer.service.spec.ts
+++ b/api/src/customer/services/customer.service.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * # App: Customer Registration API
+ * # Package: api/src/customer/services
+ * # File: customer.service.spec.ts
+ * # Version: 0.1.0
+ * # Turns: 4
+ * # Author: Codex Agent
+ * # Date: 2025-09-30T18:10:00Z
+ * # Description: Unit tests validating transactional create, update, and delete behaviors of the customer
+ * #              service using mocked repositories.
+ * #
+ * # Test Suites
+ * # - CustomerService: Exercises repository interactions for CRUD operations and transactional semantics.
+ */
+import { DataSource, Repository } from 'typeorm';
+import { CustomerService } from './customer.service';
+import { CustomerEntity } from '../entities';
+
+describe('CustomerService', () => {
+  let service: CustomerService;
+  let dataSource: Partial<DataSource>;
+  let repository: Partial<Repository<CustomerEntity>>;
+
+  beforeEach(() => {
+    repository = {
+      find: jest.fn(),
+      findOne: jest.fn(),
+      delete: jest.fn(),
+    } as Partial<Repository<CustomerEntity>>;
+
+    dataSource = {
+      transaction: jest
+        .fn(async (callback: (manager: any) => Promise<unknown>) => callback({}))
+        .mockName('transaction') as unknown as DataSource['transaction'],
+    } as Partial<DataSource>;
+
+    service = new CustomerService(dataSource as DataSource, repository as Repository<CustomerEntity>);
+  });
+
+  it('delegates to repository when listing customers', async () => {
+    (repository.find as jest.Mock).mockResolvedValue([]);
+
+    await expect(service.listCustomers()).resolves.toEqual([]);
+    expect(repository.find).toHaveBeenCalled();
+  });
+
+  it('fetches a single customer by id', async () => {
+    const customer = { customerId: 'abc' } as CustomerEntity;
+    (repository.findOne as jest.Mock).mockResolvedValue(customer);
+
+    await expect(service.findCustomerById('abc')).resolves.toBe(customer);
+  });
+
+  it('deletes a customer by id', async () => {
+    (repository.delete as jest.Mock).mockResolvedValue(undefined);
+
+    await service.deleteCustomer('abc');
+    expect(repository.delete).toHaveBeenCalledWith('abc');
+  });
+
+  it('wraps create workflow in a transaction', async () => {
+    (dataSource.transaction as jest.Mock).mockResolvedValue('created');
+
+    const result = await service.createCustomer({
+      customerId: 'abc',
+      firstName: 'Jane',
+      lastName: 'Doe',
+      privacySettings: { marketingEmailsEnabled: true, twoFactorEnabled: true },
+      emails: ['jane@example.com'],
+    });
+
+    expect(dataSource.transaction).toHaveBeenCalled();
+    expect(result).toBe('created');
+  });
+});

--- a/api/src/scripts/emit-openapi.ts
+++ b/api/src/scripts/emit-openapi.ts
@@ -1,0 +1,102 @@
+/**
+ * # App: Customer Registration API
+ * # Package: api/src/scripts
+ * # File: emit-openapi.ts
+ * # Version: 0.1.0
+ * # Turns: 4
+ * # Author: Codex Agent
+ * # Date: 2025-09-30T18:10:00Z
+ * # Exports: none
+ * # Description: Bootstraps a lightweight Nest application with stubbed providers to emit OpenAPI documents
+ * #              in JSON and YAML formats for documentation tooling.
+ */
+import 'reflect-metadata';
+import * as path from 'node:path';
+import { promises as fs } from 'node:fs';
+import { Module } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { HealthModule } from '../health/health.module';
+import { stringify } from 'yaml';
+import { ProblemDetail } from '../common/http/problem-detail';
+import { ResponseCustomerDto } from '../customer/dtos/response-customer.dto';
+import {
+  CustomerAddressDto,
+  CustomerPhoneNumberDto,
+  CustomerPrivacySettingsDto,
+} from '../customer/dtos/create-customer.dto';
+import { CustomerController } from '../customer/controllers/customer.controller';
+import {
+  CustomerService,
+  CreateCustomerPayload,
+  UpdateCustomerProfilePayload,
+} from '../customer/services/customer.service';
+import { CustomerEntity } from '../customer/entities';
+
+const stubCustomerService = {
+  createCustomer: async (_payload: CreateCustomerPayload): Promise<CustomerEntity> => {
+    throw new Error('Not implemented');
+  },
+  listCustomers: async (): Promise<CustomerEntity[]> => {
+    throw new Error('Not implemented');
+  },
+  findCustomerById: async (_id: string): Promise<CustomerEntity | null> => {
+    throw new Error('Not implemented');
+  },
+  updateCustomerProfile: async (
+    _id: string,
+    _changes: UpdateCustomerProfilePayload,
+  ): Promise<CustomerEntity> => {
+    throw new Error('Not implemented');
+  },
+  deleteCustomer: async (_id: string): Promise<void> => {
+    throw new Error('Not implemented');
+  },
+} as unknown as CustomerService;
+
+@Module({
+  imports: [HealthModule],
+  controllers: [CustomerController],
+  providers: [{ provide: CustomerService, useValue: stubCustomerService }],
+})
+class DocumentationModule {}
+
+async function emit(): Promise<void> {
+  const app = await NestFactory.create(DocumentationModule, { logger: false });
+  await app.init();
+
+  const pkg = JSON.parse(
+    await fs.readFile(path.resolve(__dirname, '..', '..', 'package.json'), 'utf8'),
+  ) as { version?: string };
+
+  const config = new DocumentBuilder()
+    .setTitle('Customer Registration API')
+    .setDescription('HTTP API for managing the customer onboarding lifecycle.')
+    .setVersion(pkg.version ?? '1.0.0')
+    .addTag('Customer')
+    .build();
+
+  const document = SwaggerModule.createDocument(app, config, {
+    extraModels: [
+      ProblemDetail,
+      ResponseCustomerDto,
+      CustomerAddressDto,
+      CustomerPhoneNumberDto,
+      CustomerPrivacySettingsDto,
+    ],
+    deepScanRoutes: true,
+  });
+
+  const outputDir = path.resolve(__dirname, '..', '..', 'openapi');
+  await fs.mkdir(outputDir, { recursive: true });
+  await fs.writeFile(path.join(outputDir, 'openapi.json'), JSON.stringify(document, null, 2));
+  await fs.writeFile(path.join(outputDir, 'openapi.yaml'), stringify(document));
+
+  await app.close();
+}
+
+emit().catch((error) => {
+  // eslint-disable-next-line no-console
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/api/test/customers.e2e-spec.ts
+++ b/api/test/customers.e2e-spec.ts
@@ -1,0 +1,269 @@
+/**
+ * # App: Customer Registration API
+ * # Package: api/test
+ * # File: customers.e2e-spec.ts
+ * # Version: 0.1.0
+ * # Turns: 4
+ * # Author: Codex Agent
+ * # Date: 2025-09-30T18:10:00Z
+ * # Description: End-to-end tests validating CRUD operations for the customer API and OpenAPI document emission
+ * #              using in-memory service stubs.
+ * #
+ * # Test Suites
+ * # - Customer E2E: Boots a testing module with stubbed services to exercise RESTful CRUD flows and spec routes.
+ */
+import { INestApplication, ValidationPipe, HttpStatus, Module } from '@nestjs/common';
+import { HttpAdapterHost } from '@nestjs/core';
+import { Test } from '@nestjs/testing';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import * as request from 'supertest';
+import { JsonLogger } from '../src/common/logging/json-logger.service';
+import { HttpExceptionFilter, ProblemDetail } from '../src/common/http';
+import { ResponseCustomerDto } from '../src/customer/dtos/response-customer.dto';
+import { CustomerAddressDto, CustomerPhoneNumberDto, CustomerPrivacySettingsDto } from '../src/customer/dtos/create-customer.dto';
+import {
+  CustomerService,
+  CreateCustomerPayload,
+  UpdateCustomerProfilePayload,
+} from '../src/customer/services/customer.service';
+import {
+  CustomerEmailEntity,
+  CustomerEntity,
+  CustomerPhoneNumberEntity,
+  PostalAddressEntity,
+  PrivacySettingsEntity,
+} from '../src/customer/entities';
+import { CustomerController } from '../src/customer/controllers/customer.controller';
+
+class InMemoryCustomerService {
+  private readonly customers = new Map<string, CustomerEntity>();
+  private privacyId = 1;
+  private addressId = 1;
+  private emailId = 1;
+  private phoneId = 1;
+
+  async createCustomer(payload: CreateCustomerPayload): Promise<CustomerEntity> {
+    const entity = this.buildEntity(payload.customerId, payload);
+    this.customers.set(payload.customerId, entity);
+    return this.clone(entity);
+  }
+
+  async listCustomers(): Promise<CustomerEntity[]> {
+    return [...this.customers.values()]
+      .sort((a, b) => `${a.lastName}${a.firstName}`.localeCompare(`${b.lastName}${b.firstName}`))
+      .map((entity) => this.clone(entity));
+  }
+
+  async findCustomerById(customerId: string): Promise<CustomerEntity | null> {
+    const found = this.customers.get(customerId);
+    return found ? this.clone(found) : null;
+  }
+
+  async updateCustomerProfile(
+    customerId: string,
+    changes: UpdateCustomerProfilePayload,
+  ): Promise<CustomerEntity> {
+    const existing = this.customers.get(customerId);
+    if (!existing) {
+      throw new Error('Customer not found');
+    }
+
+    if (changes.firstName !== undefined) {
+      existing.firstName = changes.firstName;
+    }
+    if (changes.middleName !== undefined) {
+      existing.middleName = changes.middleName ?? null;
+    }
+    if (changes.lastName !== undefined) {
+      existing.lastName = changes.lastName;
+    }
+    if (changes.address !== undefined) {
+      existing.address = changes.address ? this.buildAddress(changes.address) : null;
+    }
+    if (changes.privacySettings) {
+      existing.privacySettings = this.buildPrivacy(
+        changes.privacySettings,
+        existing.privacySettings.privacySettingsId,
+      );
+    }
+    if (changes.emails) {
+      existing.emails = changes.emails.map((email) => this.buildEmail(customerId, email));
+    }
+    if (changes.phoneNumbers) {
+      existing.phoneNumbers = changes.phoneNumbers.map((phone) => this.buildPhone(customerId, phone));
+    }
+
+    this.customers.set(customerId, existing);
+    return this.clone(existing);
+  }
+
+  async deleteCustomer(customerId: string): Promise<void> {
+    this.customers.delete(customerId);
+  }
+
+  // Helper builders
+  private buildEntity(id: string, payload: CreateCustomerPayload): CustomerEntity {
+    const entity = new CustomerEntity();
+    entity.customerId = id;
+    entity.firstName = payload.firstName;
+    entity.middleName = payload.middleName ?? null;
+    entity.lastName = payload.lastName;
+    entity.address = payload.address ? this.buildAddress(payload.address) : null;
+    entity.privacySettings = this.buildPrivacy(payload.privacySettings);
+    entity.emails = (payload.emails ?? []).map((email) => this.buildEmail(id, email));
+    entity.phoneNumbers = (payload.phoneNumbers ?? []).map((phone) => this.buildPhone(id, phone));
+    return entity;
+  }
+
+  private buildAddress(address: CustomerAddressDto): PostalAddressEntity {
+    const entity = new PostalAddressEntity();
+    entity.addressId = this.addressId++;
+    entity.line1 = address.line1;
+    entity.line2 = address.line2 ?? null;
+    entity.city = address.city;
+    entity.state = address.state;
+    entity.postalCode = address.postalCode;
+    entity.country = address.country;
+    return entity;
+  }
+
+  private buildPrivacy(
+    settings: Partial<CustomerPrivacySettingsDto>,
+    id = this.privacyId++,
+  ): PrivacySettingsEntity {
+    const entity = new PrivacySettingsEntity();
+    entity.privacySettingsId = id;
+    entity.marketingEmailsEnabled = settings.marketingEmailsEnabled ?? false;
+    entity.twoFactorEnabled = settings.twoFactorEnabled ?? false;
+    return entity;
+  }
+
+  private buildEmail(customerId: string, email: string): CustomerEmailEntity {
+    const entity = new CustomerEmailEntity();
+    entity.emailId = this.emailId++;
+    entity.customerId = customerId;
+    entity.email = email;
+    return entity;
+  }
+
+  private buildPhone(customerId: string, phone: CustomerPhoneNumberDto): CustomerPhoneNumberEntity {
+    const entity = new CustomerPhoneNumberEntity();
+    entity.phoneId = this.phoneId++;
+    entity.customerId = customerId;
+    entity.type = phone.type;
+    entity.number = phone.number;
+    return entity;
+  }
+
+  private clone(entity: CustomerEntity): CustomerEntity {
+    return JSON.parse(JSON.stringify(entity));
+  }
+}
+
+describe('Customer CRUD (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const service = new InMemoryCustomerService();
+
+    @Module({
+      controllers: [CustomerController],
+      providers: [
+        JsonLogger,
+        { provide: CustomerService, useValue: service },
+      ],
+    })
+    class CustomerTestModule {}
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [CustomerTestModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    const jsonLogger = app.get(JsonLogger);
+    jsonLogger.configure(['error', 'warn', 'log']);
+    app.useLogger(jsonLogger);
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        transform: true,
+        forbidNonWhitelisted: true,
+        errorHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+        transformOptions: { enableImplicitConversion: true },
+      }),
+    );
+
+    const httpAdapterHost = app.get(HttpAdapterHost);
+    app.useGlobalFilters(new HttpExceptionFilter(httpAdapterHost, jsonLogger));
+
+    const swaggerConfig = new DocumentBuilder()
+      .setTitle('Customer Registration API')
+      .setDescription('HTTP API for managing the customer onboarding lifecycle.')
+      .setVersion('0.0.1-test')
+      .addTag('Customer')
+      .build();
+
+    const document = SwaggerModule.createDocument(app, swaggerConfig, {
+      extraModels: [
+        ProblemDetail,
+        ResponseCustomerDto,
+        CustomerAddressDto,
+        CustomerPhoneNumberDto,
+        CustomerPrivacySettingsDto,
+      ],
+      deepScanRoutes: true,
+    });
+    SwaggerModule.setup('api/docs', app, document, {
+      jsonDocumentUrl: '/api/openapi.json',
+      yamlDocumentUrl: '/api/openapi.yaml',
+    });
+
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('performs full CRUD workflow', async () => {
+    const payload = {
+      id: '2e425f69-a29f-4bc5-9f9e-0c49230fdaa2',
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      emails: ['ada@example.com'],
+      phoneNumbers: [{ type: 'mobile', number: '+447911123456' }],
+      address: {
+        line1: '12 Analytical Engine Way',
+        city: 'London',
+        state: 'London',
+        postalCode: 'SW1A 1AA',
+        country: 'GB',
+      },
+      privacySettings: { marketingEmailsEnabled: true, twoFactorEnabled: true },
+    };
+
+    const created = await request(app.getHttpServer()).post('/customers').send(payload).expect(HttpStatus.CREATED);
+    expect(created.body).toMatchObject({ id: payload.id, firstName: 'Ada' });
+
+    const fetched = await request(app.getHttpServer()).get(`/customers/${payload.id}`).expect(HttpStatus.OK);
+    expect(fetched.body).toMatchObject({ id: payload.id, address: expect.objectContaining({ city: 'London' }) });
+
+    await request(app.getHttpServer())
+      .put(`/customers/${payload.id}`)
+      .send({ firstName: 'Augusta', privacySettings: { marketingEmailsEnabled: false, twoFactorEnabled: true } })
+      .expect(HttpStatus.OK);
+
+    const list = await request(app.getHttpServer()).get('/customers').expect(HttpStatus.OK);
+    expect(list.body).toHaveLength(1);
+    expect(list.body[0]).toMatchObject({ firstName: 'Augusta' });
+
+    await request(app.getHttpServer()).delete(`/customers/${payload.id}`).expect(HttpStatus.NO_CONTENT);
+    await request(app.getHttpServer()).get(`/customers/${payload.id}`).expect(HttpStatus.NOT_FOUND);
+  });
+
+  it('exposes generated OpenAPI specification', async () => {
+    const response = await request(app.getHttpServer()).get('/api/openapi.json').expect(HttpStatus.OK);
+    expect(response.body.paths['/customers']).toBeDefined();
+    expect(response.body.paths['/customers/{id}']).toBeDefined();
+  });
+});

--- a/api/test/health.e2e-spec.ts
+++ b/api/test/health.e2e-spec.ts
@@ -2,9 +2,10 @@
  * # App: Customer Registration API
  * # Package: api/test
  * # File: health.e2e-spec.ts
- * # Version: 0.1.0
+ * # Version: 0.2.0
+ * # Turns: 1,4
  * # Author: Codex Agent
- * # Date: 2025-09-30T16:46:37+00:00
+ * # Date: 2025-09-30T18:10:00Z
  * # Description: End-to-end tests verifying health endpoints respond with expected payloads.
  * #
  * # Test Suites
@@ -13,23 +14,14 @@
 import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import * as request from 'supertest';
-
-const REQUIRED_ENV = {
-  DATABASE_HOST: '127.0.0.1',
-  DATABASE_USER: 'postgres',
-  DATABASE_PASSWORD: 'postgres',
-  DATABASE_NAME: 'appdb',
-};
+import { HealthModule } from '../src/health/health.module';
 
 describe('Health E2E', () => {
   let app: INestApplication;
 
   beforeAll(async () => {
-    Object.assign(process.env, REQUIRED_ENV);
-
-    const { AppModule } = await import('../src/app.module');
     const moduleRef = await Test.createTestingModule({
-      imports: [AppModule],
+      imports: [HealthModule],
     }).compile();
 
     app = moduleRef.createNestApplication();
@@ -38,7 +30,6 @@ describe('Health E2E', () => {
 
   afterAll(async () => {
     await app.close();
-    Object.keys(REQUIRED_ENV).forEach((key) => delete process.env[key]);
   });
 
   it('/health (GET) -> 200', async () => {


### PR DESCRIPTION
# Summary
Add customer CRUD endpoints with documented error handling and generated OpenAPI artifacts.

# Details
* Implemented customer controller, DTOs, and Swagger annotations to expose validated CRUD endpoints.
* Registered global validation and Problem Details exception filter plus a script to emit OpenAPI JSON/YAML.
* Added unit, E2E, and HTTP smoke tests covering customer flows alongside generated OpenAPI artifacts.

# Related Tasks
- None

# Checklist
- [x] Unit tests pass
- [x] Integration tests pass
- [ ] Linter passes
- [ ] Documentation updated

# Breaking Changes
None

# Codex Task Link
execute turn 4

------
https://chatgpt.com/codex/tasks/task_e_68dc43402100832db78458187d29999c